### PR TITLE
Change default hotkey from Cmd+Shift+Space to Option+Space

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ swiftc -parse-as-library Extremis/Tests/Core/SessionManagerTests.swift -o /tmp/t
 ## Project Overview
 
 Extremis is a macOS menu bar app that provides context-aware LLM text generation via global hotkeys:
-- **Cmd+Shift+Space**: Opens Quick Mode (with selection) or Chat Mode (without selection)
+- **Option+Space**: Opens Quick Mode (with selection) or Chat Mode (without selection)
 - **Option+Tab**: Magic Mode - summarizes selected text (no-op without selection)
 
 Context is captured via AX metadata (app name, window title) and selected text when present.

--- a/Extremis/Core/Models/Preferences.swift
+++ b/Extremis/Core/Models/Preferences.swift
@@ -36,10 +36,10 @@ struct HotkeyConfiguration: Codable, Equatable {
         self.modifiers = modifiers
     }
     
-    /// Default hotkey: ⌘+Shift+Space
+    /// Default hotkey: ⌥+Space (Option+Space)
     static let `default` = HotkeyConfiguration(
         keyCode: UInt32(kVK_Space),      // Space key
-        modifiers: UInt32(cmdKey | shiftKey)  // Cmd + Shift
+        modifiers: UInt32(optionKey)     // Option
     )
     
     /// Human-readable description of the hotkey

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A context-aware LLM writing assistant for macOS. Press a global hotkey anywhere 
 ## Features
 
 - **Global Hotkeys**
-  - `Cmd+Shift+Space` - Quick Mode (with selection) or Chat Mode (without selection)
+  - `Option+Space` - Quick Mode (with selection) or Chat Mode (without selection)
   - `Option+Tab` - Magic Mode: auto-summarize selected text (no-op without selection)
 - **Context-Aware** - Captures app context (name, window title) and selected text
 - **Quick Summarization** - Summarize selected text instantly with one keystroke
@@ -76,17 +76,17 @@ If you prefer cloud-based models:
 
 ## Usage
 
-### Quick Mode / Chat Mode (`Cmd+Shift+Space`)
+### Quick Mode / Chat Mode (`Option+Space`)
 
 The hotkey behavior depends on whether you have text selected:
 
 **With text selected (Quick Mode):**
-1. Press `Cmd+Shift+Space` with text selected
+1. Press `Option+Space` with text selected
 2. Click **Summarize** for instant summary, or type an instruction to transform the text
 3. Press `Cmd+Enter` to insert or `Cmd+C` to copy
 
 **Without selection (Chat Mode):**
-1. Press `Cmd+Shift+Space` without any text selected
+1. Press `Option+Space` without any text selected
 2. A conversational chat interface opens
 3. Type your question or request and press Enter
 4. Continue the conversation with follow-up questions


### PR DESCRIPTION
## Summary

Update the default main hotkey from Cmd + Shift + Space to Option + Space to align with established patterns (ChatGPT, Raycast) and refresh related documentation.

## Changes

- **Preferences.swift** – changed modifier from `cmdKey | shiftKey` to `optionKey`.
- **CLAUDE.md** – updated documentation to reflect the new hotkey.
- **README.md** – revised all hotkey references.
- Added clarification of hotkey mappings:
  - `Option + Space` – Quick Mode / Chat Mode  
  - `Option + Tab` – Magic Mode (unchanged)

## Related Issue

Fixes #55

## Testing

- [x] Build passes (`swift build`)
- [x] All tests pass (`./scripts/run-tests.sh`)
- [x] Manual testing completed (verify Option + Space triggers Quick/Chat mode and Option + Tab still triggers Magic mode)

## Checklist

- [x] Code follows project conventions
- [x] No new warnings introduced
- [x] Documentation updated (if applicable)
- [x] CLAUDE.md updated (if new patterns/features added)