### PR TITLE
Simplify SelectionDetector to Cmd+C only and remove dead context fields

### DIFF
--- a/Extremis/App/AppDelegate.swift
+++ b/Extremis/App/AppDelegate.swift
@@ -428,8 +428,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let context = Context(
             source: source,
             selectedText: text,
-            precedingText: nil,
-            succeedingText: nil,
             metadata: .generic(GenericMetadata())
         )
 
@@ -459,9 +457,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
             let context = Context(
                 source: source,
-                selectedText: selectedText,
-                precedingText: nil,
-                succeedingText: nil
+                selectedText: selectedText
             )
             currentContext = context
             logCapturedContext(context)
@@ -478,9 +474,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
             let context = Context(
                 source: source,
-                selectedText: nil,
-                precedingText: nil,
-                succeedingText: nil
+                selectedText: nil
             )
             currentContext = context
             logCapturedContext(context)
@@ -507,14 +501,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         print("\n📝 SELECTED TEXT:")
         if let selected = context.selectedText, !selected.isEmpty {
             print("    \"\(selected.prefix(200))\(selected.count > 200 ? "..." : "")\"")
-        } else {
-            print("    (none)")
-        }
-
-        // Preceding Text
-        print("\n📄 PRECEDING TEXT:")
-        if let preceding = context.precedingText, !preceding.isEmpty {
-            print("    \"\(preceding.prefix(200))\(preceding.count > 200 ? "..." : "")\"")
         } else {
             print("    (none)")
         }

--- a/Extremis/Core/Models/Context.swift
+++ b/Extremis/Core/Models/Context.swift
@@ -4,17 +4,9 @@
 import Foundation
 
 // MARK: - Context Text Limits
-// Maximum characters stored for each text field.
-// This prevents memory issues with extremely large selections/documents.
 
 /// Maximum characters for selected text
 private let kContextMaxSelectedTextLength = 50000
-
-/// Maximum characters for preceding text (text before cursor)
-private let kContextMaxPrecedingTextLength = 50000
-
-/// Maximum characters for succeeding text (text after cursor)
-private let kContextMaxSucceedingTextLength = 50000
 
 // MARK: - Core Context
 
@@ -24,8 +16,6 @@ struct Context: Codable, Equatable, Identifiable {
     let capturedAt: Date
     let source: ContextSource
     let selectedText: String?
-    let precedingText: String?
-    let succeedingText: String?  // Text after the cursor
     let metadata: ContextMetadata
 
     init(
@@ -33,17 +23,12 @@ struct Context: Codable, Equatable, Identifiable {
         capturedAt: Date = Date(),
         source: ContextSource,
         selectedText: String? = nil,
-        precedingText: String? = nil,
-        succeedingText: String? = nil,
         metadata: ContextMetadata = .generic(GenericMetadata())
     ) {
         self.id = id
         self.capturedAt = capturedAt
         self.source = source
-        // Truncate text fields to prevent storing excessively large content
         self.selectedText = Context.truncateSelectedText(selectedText)
-        self.precedingText = Context.truncatePrecedingText(precedingText)
-        self.succeedingText = Context.truncateSucceedingText(succeedingText)
         self.metadata = metadata
     }
 
@@ -54,20 +39,6 @@ struct Context: Codable, Equatable, Identifiable {
         guard let text = text else { return nil }
         guard text.count > kContextMaxSelectedTextLength else { return text }
         return String(text.prefix(kContextMaxSelectedTextLength))
-    }
-
-    /// Truncates preceding text from the beginning, keeping the suffix (closest to cursor)
-    private static func truncatePrecedingText(_ text: String?) -> String? {
-        guard let text = text else { return nil }
-        guard text.count > kContextMaxPrecedingTextLength else { return text }
-        return String(text.suffix(kContextMaxPrecedingTextLength))
-    }
-
-    /// Truncates succeeding text from the end, keeping the prefix (closest to cursor)
-    private static func truncateSucceedingText(_ text: String?) -> String? {
-        guard let text = text else { return nil }
-        guard text.count > kContextMaxSucceedingTextLength else { return text }
-        return String(text.prefix(kContextMaxSucceedingTextLength))
     }
 }
 

--- a/Extremis/Extractors/BrowserExtractor.swift
+++ b/Extremis/Extractors/BrowserExtractor.swift
@@ -66,8 +66,6 @@ final class BrowserExtractor: ContextExtractor {
         return Context(
             source: source,
             selectedText: selectedText,
-            precedingText: nil,
-            succeedingText: nil,
             metadata: .generic(GenericMetadata(
                 focusedElementRole: focusedInfo.role,
                 focusedElementLabel: focusedInfo.label

--- a/Extremis/Extractors/GenericExtractor.swift
+++ b/Extremis/Extractors/GenericExtractor.swift
@@ -43,8 +43,6 @@ final class GenericExtractor: ContextExtractor {
         return Context(
             source: source,
             selectedText: selectedText,
-            precedingText: nil,
-            succeedingText: nil,
             metadata: .generic(GenericMetadata(
                 focusedElementRole: focusedInfo.role,
                 focusedElementLabel: focusedInfo.label

--- a/Extremis/Extractors/SlackExtractor.swift
+++ b/Extremis/Extractors/SlackExtractor.swift
@@ -82,8 +82,6 @@ final class SlackExtractor: ContextExtractor {
         return Context(
             source: source,
             selectedText: selectedText,
-            precedingText: nil,
-            succeedingText: nil,
             metadata: .slack(metadata)
         )
     }

--- a/Extremis/Tests/LLMProviders/PromptBuilderTests.swift
+++ b/Extremis/Tests/LLMProviders/PromptBuilderTests.swift
@@ -191,16 +191,11 @@ enum ContextMetadata: Codable, Equatable {
 struct Context: Codable, Equatable {
     let source: ContextSource
     let selectedText: String?
-    let precedingText: String?
-    let succeedingText: String?
     var metadata: ContextMetadata
 
-    init(source: ContextSource, selectedText: String?, precedingText: String?,
-         succeedingText: String?, metadata: ContextMetadata = .generic(GenericMetadata())) {
+    init(source: ContextSource, selectedText: String?, metadata: ContextMetadata = .generic(GenericMetadata())) {
         self.source = source
         self.selectedText = selectedText
-        self.precedingText = precedingText
-        self.succeedingText = succeedingText
         self.metadata = metadata
     }
 }
@@ -564,9 +559,7 @@ struct ChatMessageIntentTests {
     static func testUserMessageWithContext() {
         let context = Context(
             source: ContextSource(applicationName: "Notes", bundleIdentifier: "com.apple.Notes"),
-            selectedText: "Selected text",
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: "Selected text"
         )
         let message = ChatMessage.user("Transform this", context: context)
         TestRunner.assertEqual(message.role, .user, "ChatMessage.user with context: role")
@@ -577,9 +570,7 @@ struct ChatMessageIntentTests {
     static func testUserMessageWithContextAndIntent() {
         let context = Context(
             source: ContextSource(applicationName: "Safari", bundleIdentifier: "com.apple.Safari"),
-            selectedText: "Text to summarize",
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: "Text to summarize"
         )
         let message = ChatMessage.user("Summarize", context: context, intent: .summarize)
         TestRunner.assertEqual(message.intent, .summarize, "ChatMessage.user with intent: intent correct")
@@ -630,9 +621,7 @@ struct PromptBuilderIntentTests {
     func testFormatUserMessageWithContext_WithContext() {
         let context = Context(
             source: ContextSource(applicationName: "Notes", bundleIdentifier: "com.apple.Notes"),
-            selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: nil
         )
         let result = builder.formatUserMessageWithContext("Hello", context: context, intent: .chat)
         TestRunner.assertTrue(result.contains("[Context]"), "formatUserMessage: has context block")
@@ -644,9 +633,7 @@ struct PromptBuilderIntentTests {
     func testFormatUserMessageWithContext_ChatIntent() {
         let context = Context(
             source: ContextSource(applicationName: "Notes", bundleIdentifier: "com.apple.Notes"),
-            selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: nil
         )
         let result = builder.formatUserMessageWithContext("What is this?", context: context, intent: .chat)
         TestRunner.assertTrue(result.contains("[User Message]"), "formatUserMessage chat: has [User Message]")
@@ -656,9 +643,7 @@ struct PromptBuilderIntentTests {
     func testFormatUserMessageWithContext_TransformIntent() {
         let context = Context(
             source: ContextSource(applicationName: "Notes", bundleIdentifier: "com.apple.Notes"),
-            selectedText: "Text to transform",
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: "Text to transform"
         )
         let result = builder.formatUserMessageWithContext("Make formal", context: context, intent: .selectionTransform)
         TestRunner.assertTrue(result.contains("[Instruction]"), "formatUserMessage transform: has [Instruction]")
@@ -672,9 +657,7 @@ struct PromptBuilderIntentTests {
     func testFormatUserMessageWithContext_SummarizeIntent() {
         let context = Context(
             source: ContextSource(applicationName: "Safari", bundleIdentifier: "com.apple.Safari"),
-            selectedText: "Long article content here",
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: "Long article content here"
         )
         let result = builder.formatUserMessageWithContext("Summarize", context: context, intent: .summarize)
         TestRunner.assertTrue(result.contains("[Request]"), "formatUserMessage summarize: has [Request]")
@@ -686,9 +669,7 @@ struct PromptBuilderIntentTests {
     func testFormatUserMessageWithContext_FollowUpIntent() {
         let context = Context(
             source: ContextSource(applicationName: "Notes", bundleIdentifier: "com.apple.Notes"),
-            selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: nil
         )
         let result = builder.formatUserMessageWithContext("What else?", context: context, intent: .followUp)
         TestRunner.assertTrue(result.contains("[User Message]"), "formatUserMessage followUp: has [User Message]")
@@ -698,9 +679,7 @@ struct PromptBuilderIntentTests {
     func testFormatUserMessageWithContext_NilIntent() {
         let context = Context(
             source: ContextSource(applicationName: "Notes", bundleIdentifier: "com.apple.Notes"),
-            selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: nil
         )
         let result = builder.formatUserMessageWithContext("Hello", context: context, intent: nil)
         TestRunner.assertTrue(result.contains("[User Message]"), "formatUserMessage nil intent: defaults to chat")
@@ -758,9 +737,7 @@ struct FormatChatMessagesTests {
     func testUserMessageWithContext() {
         let context = Context(
             source: ContextSource(applicationName: "Notes", bundleIdentifier: "com.apple.Notes"),
-            selectedText: "Selected",
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: "Selected"
         )
         let messages = [ChatMessage.user("Transform", context: context, intent: .selectionTransform)]
         let result = builder.formatChatMessages(messages: messages)
@@ -815,9 +792,7 @@ struct ContextFormattingTests {
                 bundleIdentifier: "com.apple.Notes",
                 windowTitle: "My Document"
             ),
-            selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: nil
         )
         let result = builder.formatUserMessageWithContext("Hello", context: context, intent: .chat)
         TestRunner.assertTrue(result.contains("Window: My Document"), "Context: window title included")
@@ -830,9 +805,7 @@ struct ContextFormattingTests {
                 bundleIdentifier: "com.apple.Safari",
                 url: URL(string: "https://example.com/page")
             ),
-            selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: nil
         )
         let result = builder.formatUserMessageWithContext("Hello", context: context, intent: .chat)
         TestRunner.assertTrue(result.contains("URL: https://example.com/page"), "Context: URL included")
@@ -841,9 +814,7 @@ struct ContextFormattingTests {
     func testContextWithSelectedText() {
         let context = Context(
             source: ContextSource(applicationName: "Notes", bundleIdentifier: "com.apple.Notes"),
-            selectedText: "This is selected",
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: "This is selected"
         )
         let result = builder.formatUserMessageWithContext("Hello", context: context, intent: .chat)
         TestRunner.assertTrue(result.contains("Selected Text:"), "Context: selected text label")
@@ -859,9 +830,7 @@ struct ContextFormattingTests {
                 windowTitle: "GitHub - Pull Request",
                 url: URL(string: "https://github.com/org/repo/pull/123")
             ),
-            selectedText: "Code to review",
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: "Code to review"
         )
         let result = builder.formatUserMessageWithContext("Review", context: context, intent: .chat)
         TestRunner.assertTrue(result.contains("Application: Safari"), "Context all: app")
@@ -881,8 +850,6 @@ struct ContextFormattingTests {
         let context = Context(
             source: ContextSource(applicationName: "Slack", bundleIdentifier: "com.tinyspeck.slackmacgap"),
             selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil,
             metadata: .slack(slackMeta)
         )
         let result = builder.formatUserMessageWithContext("Reply", context: context, intent: .chat)
@@ -904,8 +871,6 @@ struct ContextFormattingTests {
         let context = Context(
             source: ContextSource(applicationName: "Gmail", bundleIdentifier: "com.google.Chrome"),
             selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil,
             metadata: .gmail(gmailMeta)
         )
         let result = builder.formatUserMessageWithContext("Reply", context: context, intent: .chat)
@@ -977,9 +942,7 @@ struct EdgeCaseTests {
     func testEmptySelectedText() {
         let context = Context(
             source: ContextSource(applicationName: "Notes", bundleIdentifier: "com.apple.Notes"),
-            selectedText: "",
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: ""
         )
         let result = builder.formatUserMessageWithContext("Hello", context: context, intent: .chat)
         TestRunner.assertFalse(result.contains("Selected Text:"), "Edge: empty selected text not shown")
@@ -1003,9 +966,7 @@ struct TemplateForIntentTests {
         let builder = PromptBuilder()
         let context = Context(
             source: ContextSource(applicationName: "Test", bundleIdentifier: "test"),
-            selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: nil
         )
         let result = builder.formatUserMessageWithContext("test", context: context, intent: .chat)
         TestRunner.assertTrue(result.contains("[User Message]"), "templateForIntent: chat -> intentChat")
@@ -1015,9 +976,7 @@ struct TemplateForIntentTests {
         let builder = PromptBuilder()
         let context = Context(
             source: ContextSource(applicationName: "Test", bundleIdentifier: "test"),
-            selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: nil
         )
         let result = builder.formatUserMessageWithContext("test", context: context, intent: .followUp)
         TestRunner.assertTrue(result.contains("[User Message]"), "templateForIntent: followUp -> intentChat")
@@ -1027,9 +986,7 @@ struct TemplateForIntentTests {
         let builder = PromptBuilder()
         let context = Context(
             source: ContextSource(applicationName: "Test", bundleIdentifier: "test"),
-            selectedText: nil,
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: nil
         )
         let result = builder.formatUserMessageWithContext("test", context: context, intent: nil)
         TestRunner.assertTrue(result.contains("[User Message]"), "templateForIntent: nil -> intentChat")
@@ -1039,9 +996,7 @@ struct TemplateForIntentTests {
         let builder = PromptBuilder()
         let context = Context(
             source: ContextSource(applicationName: "Test", bundleIdentifier: "test"),
-            selectedText: "text",
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: "text"
         )
         let result = builder.formatUserMessageWithContext("transform", context: context, intent: .selectionTransform)
         TestRunner.assertTrue(result.contains("[Instruction]"), "templateForIntent: selectionTransform -> intentInstruct")
@@ -1051,9 +1006,7 @@ struct TemplateForIntentTests {
         let builder = PromptBuilder()
         let context = Context(
             source: ContextSource(applicationName: "Test", bundleIdentifier: "test"),
-            selectedText: "text",
-            precedingText: nil,
-            succeedingText: nil
+            selectedText: "text"
         )
         let result = builder.formatUserMessageWithContext("summarize", context: context, intent: .summarize)
         TestRunner.assertTrue(result.contains("[Request]"), "templateForIntent: summarize -> intentSummarize")

--- a/Extremis/UI/PromptWindow/ContextViewerSheet.swift
+++ b/Extremis/UI/PromptWindow/ContextViewerSheet.swift
@@ -58,14 +58,6 @@ struct ContextViewerSheet: View {
                         textSection(title: "Selected Text", content: selectedText, sectionId: "selected")
                     }
 
-                    if let precedingText = context.precedingText, !precedingText.isEmpty {
-                        textSection(title: "Preceding Text", content: precedingText, sectionId: "preceding")
-                    }
-
-                    if let succeedingText = context.succeedingText, !succeedingText.isEmpty {
-                        textSection(title: "Succeeding Text", content: succeedingText, sectionId: "succeeding")
-                    }
-
                     metadataSection
                 }
                 .padding()
@@ -472,8 +464,6 @@ struct ContextViewerSheet_Previews: PreviewProvider {
                     url: nil
                 ),
                 selectedText: "func calculateTotal() -> Double {\n    return items.reduce(0) { $0 + $1.price }\n}",
-                precedingText: "// MARK: - Shopping Cart\n\nclass ShoppingCart {\n    var items: [CartItem] = []\n    ",
-                succeedingText: "\n\n    func addItem(_ item: CartItem) {\n        items.append(item)\n    }\n}",
                 metadata: .generic(GenericMetadata(focusedElementRole: "AXTextArea", focusedElementLabel: "Editor"))
             ),
             onDismiss: {}


### PR DESCRIPTION
## Summary

Simplifies the selection detection system by removing the unreliable AX API path and using clipboard-based detection (Cmd+C) exclusively. Also removes dead `precedingText`/`succeedingText` fields from the Context model.

Fixes #74

## Changes

- **SelectionDetector.swift**: Remove AX API path (`tryAXSelection` method), use Cmd+C only
- **SelectionDetector.swift**: Remove `focusedElement` from `SelectionResult` (unused downstream)
- **SelectionDetector.swift**: Optimize timing delays (30ms clipboard wait, 5ms key delay) - 42% faster
- **Context.swift**: Remove dead `precedingText` and `succeedingText` fields
- **Extractors & UI**: Update all call sites to remove dead field references

## Why

- AX API was unreliable for Electron apps (VS Code, Slack, etc.)
- Cmd+C clipboard-based detection works consistently across all apps
- Dead context fields were never used after initial capture

## Testing

- [x] Build passes (`swift build`)
- [x] All tests pass (`./scripts/run-tests.sh`) - 590 tests
- [x] Manual testing completed - selection detection works in native apps, browsers, and IDEs

## Checklist

- [x] Code follows project conventions
- [x] No new warnings introduced
- [x] Documentation updated (if applicable)
- [x] CLAUDE.md updated (if new patterns/features added)