### PR TITLE
Build readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,24 +53,21 @@ A context-aware AI assistant for macOS that lives in your menu bar. Press a glob
 ```bash
 git clone https://github.com/an09mous/Extremis.git
 cd Extremis/Extremis
-swift build -c release
-cp -r .build/release/Extremis.app /Applications/
+./scripts/build.sh
+open build/Extremis.dmg
 ```
+
+Drag Extremis to Applications from the DMG.
 
 ### Download Pre-built
 
-Download the latest release from [GitHub Releases](https://github.com/an09mous/Extremis/releases):
-
-1. Download **Extremis.dmg** from the latest release
+1. Download **Extremis.dmg** from [GitHub Releases](https://github.com/an09mous/Extremis/releases)
 2. Open the DMG and drag Extremis to Applications
-3. Launch from Applications
-
-**macOS Gatekeeper Warning:** Since Extremis isn't notarized with Apple, you may see:
-- *"Extremis can't be opened"* → Right-click → Open → Click "Open" in the dialog
-- *"Extremis is damaged and can't be opened"* → Run this in Terminal:
-  ```bash
-  xattr -cr /Applications/Extremis.app
-  ```
+3. Run this command to bypass Gatekeeper (app isn't notarized):
+   ```bash
+   xattr -cr /Applications/Extremis.app
+   ```
+4. Launch Extremis from Applications
 
 ## Permissions
 


### PR DESCRIPTION
## Overview

Updates the README to reflect the new build workflow and simplifies the pre‑built installation instructions.

## Key Changes
- Replaces manual `swift build` steps with the helper script `./scripts/build.sh` and opens the generated `Extremis.dmg`.
- Consolidates pre‑built installation steps:
  1. Download **Extremis.dmg** from the latest GitHub release.
  2. Open the DMG and drag Extremis to Applications.
  3. Run `xattr -cr /Applications/Extremis.app` to bypass Gatekeeper (the app isn’t notarized).
  4. Launch Extremis from Applications.
- Minor wording and formatting improvements throughout the README.

This PR ensures the documentation matches the current build process and provides clearer guidance for users installing the pre‑built binary.
