### PR TITLE
Fix shell sandbox restrictions, empty response, and update README

### DIFF
--- a/Extremis/UI/PromptWindow/PromptWindowController.swift
+++ b/Extremis/UI/PromptWindow/PromptWindowController.swift
@@ -1336,6 +1336,12 @@ final class PromptViewModel: ObservableObject {
                     let totalCalls = completedToolRounds.reduce(0) { $0 + $1.toolCalls.count }
                     print("🔧 Persisted \(completedToolRounds.count) tool rounds (\(totalCalls) calls), finalContent: '\(contentToSave.prefix(50))...'")
                 }
+            } else {
+                // LLM returned empty text with no tool calls - show a fallback message
+                let emptyMessage = "[No response generated. Try rephrasing your request.]"
+                sess.addAssistantMessage(emptyMessage)
+                self.response = emptyMessage
+                print("⚠️ Generation completed with empty response - showing fallback message")
             }
             sess.clearStreamingContent()
 

--- a/README.md
+++ b/README.md
@@ -2,65 +2,29 @@
 
 A context-aware AI assistant for macOS that lives in your menu bar. Press a global hotkey anywhere to chat, transform text, execute tools, and get things done — all with full awareness of your current app, window, and selection.
 
-<img width="597" height="471" alt="image" src="https://github.com/user-attachments/assets/23b4feec-2c11-481c-969a-589c660b4b6f" />
+[![Demo](https://img.youtube.com/vi/mCSchPCEza4/maxresdefault.jpg)](https://youtu.be/mCSchPCEza4)
 
+> **[Watch the demo →](https://youtu.be/mCSchPCEza4)** | **[All demos →](https://www.youtube.com/watch?v=zUP5TH_F-dM&list=PLltnaMY5emM9y1-78i_tKbv-Lvu0fLbUf)**
 
 ## Features
 
-**Instant Access**
-- **Global Hotkeys**
-   - Summon Extremis from any app with `Option+Space`
-   - Summarize any selected text with `Option+tab`
-
-- **Context-Aware** - Automatically captures app name, window title, URLs, and selected text
-- **Smart Text Insertion** - Results insert directly at your cursor
-
-**Powerful Conversations**
-- **Multi-turn Chat** - Have full conversations with follow-ups and refinements
-- **Session Persistence** - Conversations saved automatically, pick up where you left off
-- **Context Window Management** - Long chats automatically summarized to stay within limits
-- **Real-time Streaming** - See responses as they're generated
-
-<img width="604" height="478" alt="image" src="https://github.com/user-attachments/assets/9f13e9b6-c3b2-4f82-ae91-0c3903ec81d2" />
-
-**Quick Commands**
-- **Pinned Commands Bar** - One-click access to your most-used prompts (Proofread, Professionalize, Simplify, Explain Code)
-- **Command Palette** - Type `/` to search and execute any command
-- **Custom Commands** - Create your own reusable prompt templates in Preferences
-- **Context-Aware** - Commands automatically operate on selected text
-
-**Tool Execution (MCP)**
-- Built-in connectors: System Commands, GitHub (Copilot MCP), Web Fetch
-- Connect external tools via Model Context Protocol
-- Multi-turn agentic loops - AI can chain multiple tool calls
-- Human-in-loop approval with session memory
-- Works with any MCP-compatible server (filesystem, databases, etc.)
-
-**Background Notifications**
-- Sound alerts when Extremis needs attention while you work in other apps
-- Notifies on: tool approval needed, response complete, errors
-- Enable in Preferences → General
-
-<img width="495" height="459" alt="image" src="https://github.com/user-attachments/assets/2de96c4c-8a81-41d7-8b1a-c976feede92f" />
-
-
-**Multi-Provider Support**
-- OpenAI (GPT-4o, GPT-4o Mini, GPT-4 Turbo, GPT-4)
-- Anthropic (Claude Sonnet 4.5, Claude Haiku 4.5, Claude Opus 4.5)
-- Google Gemini (Gemini 3 Flash Preview, Gemini 2.5 Flash, Gemini 2.0 Flash)
-- Ollama (Local models - Llama, Mistral, etc.)
-
-<img width="496" height="466" alt="image" src="https://github.com/user-attachments/assets/e528395c-6a4d-47a9-af72-baae6462b2e1" />
-
+- **Global Hotkeys** — `Option+Space` to summon from any app, `Option+Tab` to instantly summarize selected text
+- **Context-Aware** — Automatically captures app name, window title, URLs, and selected text
+- **Multi-turn Chat** — Full conversations with follow-ups, session persistence, and automatic summarization
+- **Quick Commands** — Pinned commands bar, command palette (`/`), and custom prompt templates
+- **Tool Execution (MCP)** — Built-in shell, GitHub, and web fetch connectors plus any MCP-compatible server
+- **Human-in-Loop Approval** — Review and approve tool calls with session memory
+- **Multi-Provider** — OpenAI, Anthropic, Google Gemini, and Ollama (local models)
+- **Smart Text Insertion** — Results insert directly at your cursor with `Cmd+Enter`
 
 ## Requirements
 
 - macOS 13.0 (Ventura) or later
-- API key for at least one LLM provider (or Ollama for local models)
+- API key for at least one LLM provider, or Ollama for local models
 
 ## Installation
 
-### Build from Source (Recommended)
+### Build from Source
 
 ```bash
 git clone https://github.com/an09mous/Extremis.git
@@ -75,102 +39,79 @@ Drag Extremis to Applications from the DMG.
 
 1. Download **Extremis.dmg** from [GitHub Releases](https://github.com/an09mous/Extremis/releases)
 2. Open the DMG and drag Extremis to Applications
-3. Run this command to bypass Gatekeeper (app isn't notarized):
+3. Bypass Gatekeeper (app isn't notarized):
    ```bash
    xattr -cr /Applications/Extremis.app
    ```
 4. Launch Extremis from Applications
 
-## Permissions
-
-Extremis requires the following permissions to function:
-
-### Accessibility (Required)
-
-**Why:** Extremis uses macOS Accessibility APIs to:
-- Read selected text from any application
-- Detect the current app, window title, and focused element
-- Insert generated text at your cursor position
-
-**How to grant:** System Settings → Privacy & Security → Accessibility → Enable Extremis
-
-Without this permission, Extremis cannot capture context or insert text.
-
-### Keychain (Automatic)
-
-**Why:** API keys are stored securely in the macOS Keychain rather than plain text files.
-
-**How it works:** macOS will prompt you to allow Keychain access on first use. Click "Always Allow" to avoid repeated prompts.
-
 ## Setup
 
 ### 1. Grant Accessibility Permission
 
-On first launch, go to **System Settings → Privacy & Security → Accessibility** and enable Extremis. You may need to restart Extremis after granting permission.
+On first launch, go to **System Settings → Privacy & Security → Accessibility** and enable Extremis. Restart Extremis after granting permission.
 
 ### 2. Configure an LLM Provider
 
 Click the menu bar icon → **Preferences** → **Providers** tab.
 
-| Provider | Get API Key |
-|----------|-------------|
+| Provider | API Key |
+|----------|---------|
 | OpenAI | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
 | Anthropic | [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys) |
 | Google Gemini | [aistudio.google.com/app/apikey](https://aistudio.google.com/app/apikey) |
-| Ollama | No key needed - [ollama.ai](https://ollama.ai) |
+| Ollama | No key needed — see below |
 
-For Ollama: Install from ollama.ai, run `ollama pull llama3.2`, and Extremis auto-detects it.
+### Setting Up Ollama (Local Models)
+
+1. Install Ollama from [ollama.com](https://ollama.com)
+2. Start ollama
+3. Pull a model:
+   ```bash
+   ollama pull llama3.2
+   ```
+4. In Extremis, go to **Preferences → Providers → Ollama (Local)** — it auto-detects the server at `http://127.0.0.1:11434`
+5. Select your model from the dropdown
+
+Ollama models that support tool calling (e.g., `llama3.1`, `qwen2.5`) will automatically work with MCP connectors. Extremis checks each model's capabilities at runtime.
+
+To use a remote Ollama server, update the base URL in Preferences.
 
 ## Usage
 
-### `Option+Space` - Quick Mode / Chat Mode
+### `Option+Space` — Quick Mode / Chat Mode
 
 | Context | Mode | What It Does |
 |---------|------|--------------|
-| Text selected | Quick Mode | Transform or summarize selected text |
-| No selection | Chat Mode | Open conversational chat interface |
+| Text selected | Quick Mode | Transform or act on selected text |
+| No selection | Chat Mode | Open conversational chat |
 
-**Quick Mode**: Select text → `Option+Space` → Type instruction or click Summarize → `Cmd+Enter` to insert
+- **Quick Mode**: Select text → `Option+Space` → Type instruction → `Cmd+Enter` to insert
+- **Chat Mode**: `Option+Space` (no selection) → Type your question → Continue conversation
 
-**Chat Mode**: `Option+Space` (no selection) → Type your question → Continue conversation
-
-### `Option+Tab` - Magic Mode
+### `Option+Tab` — Magic Mode
 
 Instantly summarize selected text with one keystroke. Does nothing without a selection.
 
-### MCP Tools (Optional)
+### MCP Tools
 
-**Built-in Connectors** (Preferences → Connectors):
-- **System Commands** - Execute macOS shell commands (enabled by default)
-- **GitHub** - Access repos, issues, PRs via Copilot MCP (requires GitHub PAT)
-- **Web Fetch** - Fetch and process web content (enabled by default)
+**Built-in connectors** (Preferences → Connectors):
+- **System Commands** — Execute macOS shell commands
+- **GitHub** — Access repos, issues, PRs via Copilot MCP (requires GitHub PAT)
+- **Web Fetch** — Fetch and process web content
 
-**Custom MCP Servers** - Configure in `~/Library/Application Support/Extremis/mcp-servers.json`:
-
-```json
-{
-  "servers": {
-    "filesystem": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
-    }
-  }
-}
-```
-
-**Tool Approval Shortcuts:**
-- `Option+Return` - Allow all tools
-- `Option+Escape` - Deny all tools
-- Check "Remember for this session" to auto-approve repeated tool calls
+**Custom MCP servers** — Add via **Preferences → Connectors → Add MCP Server**, or edit `~/Library/Application Support/Extremis/mcp-servers.json` directly.
 
 ## Keyboard Shortcuts
 
 | Shortcut | Action |
 |----------|--------|
-| `Option+Space` | Open Extremis (Quick/Chat mode) |
+| `Option+Space` | Open Extremis |
 | `Option+Tab` | Magic Mode (instant summarize) |
 | `Cmd+Enter` | Insert generated text |
 | `Cmd+C` | Copy generated text |
+| `Option+Return` | Allow all tool calls |
+| `Option+Escape` | Deny all tool calls |
 | `Escape` | Close window |
 
 ## Privacy


### PR DESCRIPTION
## Summary

Fixes #104

- **Shell sandbox fix** — Expanded `writeCommands` set with curl, wget, python3, node, git, npm, brew, pip3, etc. Added `writeIndicators` detection for output redirection (`>`, `>>`, `| tee`) so commands bypass the read-only sandbox when they need file/network access.
- **Empty response fallback** — When LLM returns empty text with no tool calls, shows `[No response generated. Try rephrasing your request.]` instead of blank UI.
- **MCP subprocess PATH enrichment** — ProcessTransport now prepends Homebrew, nvm, volta, and other common tool paths so MCP server subprocesses can find dependencies.
- **README rewrite** — Replaced screenshots with YouTube demo video, added demos playlist link, added Ollama setup guide, streamlined content.

## Test Plan

- [x] All 1510 existing tests pass
- [x] New tests for expanded write commands classification (8 tests)
- [x] New tests for write indicator detection (5 tests)
- [x] `swift build` succeeds