### PR TITLE
Add commands and command palette section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ To use a remote Ollama server, update the base URL in Preferences.
 
 Instantly summarize selected text with one keystroke. Does nothing without a selection.
 
+### Commands
+
+- **Pinned Commands Bar** — One-click access to frequently used prompts (Proofread, Professionalize, Simplify, Explain Code) shown above the input field
+- **Command Palette** — Type `/` in the input field to search and execute any command with keyboard navigation
+- **Custom Commands** — Create your own reusable prompt templates in **Preferences → Commands**
+
+Commands automatically operate on selected text when available.
+
 ### MCP Tools
 
 **Built-in connectors** (Preferences → Connectors):


### PR DESCRIPTION
## Summary

Add documentation for the Commands feature to the README — pinned commands bar, command palette, and custom commands.

## Changes

- Added Commands section under Usage in README
- Documents pinned commands bar (Proofread, Professionalize, Simplify, Explain Code)
- Documents command palette triggered by `/`
- Documents custom commands via Preferences → Commands

## Related Issue

Fixes #106

## Testing

- [x] Documentation-only change, no code modified

## Checklist

- [x] Code follows project conventions
- [x] No new warnings introduced
- [x] Documentation updated (if applicable)
- [x] CLAUDE.md updated (if new patterns/features added)