### PR TITLE
Add streaming indicator to Quick Mode

### DIFF
--- a/Extremis/UI/PromptWindow/ResponseView.swift
+++ b/Extremis/UI/PromptWindow/ResponseView.swift
@@ -171,6 +171,19 @@ struct ResponseView: View {
                                 // Display response text if available
                                 if !response.isEmpty {
                                     if isGenerating {
+                                        // Role label with spinner (consistent with Chat Mode's StreamingMessageView)
+                                        HStack(spacing: 4) {
+                                            Image(systemName: "sparkles")
+                                                .font(.caption2)
+                                                .foregroundColor(.accentColor)
+                                            Text("Extremis")
+                                                .font(.caption2)
+                                                .foregroundColor(.secondary)
+                                            ProgressView()
+                                                .scaleEffect(0.5)
+                                                .frame(width: 12, height: 12)
+                                        }
+
                                         // Plain text during streaming for performance
                                         Text(response)
                                             .font(.body)


### PR DESCRIPTION
## Summary

Adds a streaming indicator to Quick Mode so users can see that text generation is in progress, matching the existing Chat Mode behavior.

## Changes

- Added `✦ Extremis [spinner]` role label header above streaming text in Quick Mode's `ResponseView`
- Uses the same visual pattern as Chat Mode's `StreamingMessageView` (sparkles icon + "Extremis" label + `ProgressView` spinner)
- Indicator only appears while `isGenerating` is true and response content exists; disappears when generation completes

## Related Issue

Fixes #114

## Testing

- [x] Build passes (`swift build`)
- [x] All tests pass (`./scripts/run-tests.sh`) — 1726/1726 passed
- [x] Manual testing completed

## Checklist

- [x] Code follows project conventions
- [x] No new warnings introduced
- [x] Documentation updated (if applicable) — N/A, visual-only change
- [x] CLAUDE.md updated (if new patterns/features added) — N/A