### PR TITLE
Fix CI build failure: pin MCP SDK to <0.11.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/Extremis/Package.swift
+++ b/Extremis/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.10.0"),
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", "0.10.0"..<"0.11.0"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui.git", from: "2.4.0"),
     ],
     targets: [


### PR DESCRIPTION
## Summary

Fixes CI build failure caused by MCP Swift SDK 0.11.0 requiring Swift 6.1, while CI runners have Swift 6.0.

## Changes

- Pin `swift-sdk` dependency to `"0.10.0"..<"0.11.0"` in Package.swift

## Root Cause

- `Package.resolved` is in `.gitignore`, so CI resolves dependencies fresh
- `from: "0.10.0"` allowed SPM to pick up SDK 0.11.0 (released Feb 19)
- SDK 0.11.0 uses `withThrowingTaskGroup` without `of:` parameter (Swift 6.1+ only)
- CI's Xcode ships Swift 6.0 → build fails

## Testing

- [x] Build passes locally (`swift build`)
- [x] `swift package resolve` resolves to 0.10.2 within the pinned range