### PR TITLE
Add image attachments for chat messages (#012)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ Feature specs are in `specs/` directory, each containing:
 - `tasks.md` - Task breakdown
 - `data-model.md` - Data model schemas (when applicable)
 
-Latest completed feature: `specs/011-tool-approval/` (Human-in-Loop Tool Approval) ✅
+Latest completed feature: `specs/012-image-attachments/` (Image Attachments)
 
 ## Key Files
 
@@ -210,6 +210,11 @@ Latest completed feature: `specs/011-tool-approval/` (Human-in-Loop Tool Approva
 - `Extremis/Core/Models/ShellCommand.swift` - Shell command risk classification
 - `Extremis/Core/Services/ShellCommandExecutor.swift` - Safe shell execution with sandboxing
 - `Extremis/UI/Components/DesignSystem.swift` - Centralized design tokens (colors, radii, spacing, shadows)
+- `Extremis/Core/Models/ImageAttachment.swift` - ImageAttachment model, ImageRef persistence struct, ImageFormat/ImageSourceType enums
+- `Extremis/Core/Services/ImageProcessor.swift` - Image processing, resizing, thumbnail generation (ImageIO)
+- `Extremis/Utilities/ImagePersistence.swift` - File-based image storage actor
+- `Extremis/UI/PromptWindow/ImageAttachmentView.swift` - Thumbnail strip and chat message image views
+- `Extremis/UI/PromptWindow/ImageDropZoneView.swift` - Drag-and-drop overlay
 
 ## Configuration & Storage
 
@@ -332,3 +337,11 @@ MCP servers are configured in `~/Library/Application Support/Extremis/mcp-server
 - Tool names are prefixed with server name to avoid collisions
 - Tool execution supports multi-turn loops (LLM → tools → LLM → ...)
 
+
+## Active Technologies
+- Swift 5.9+ with Swift Concurrency, SwiftUI + AppKit hybrid (NSPanel, NSHostingView, NSPasteboard, NSDragging)
+- ImageIO (CGImageSource for efficient image resizing and thumbnail generation)
+- File-based image storage in `~/Library/Application Support/Extremis/images/`, JSON session persistence with file references and inline base64 thumbnails
+
+## Recent Changes
+- 012-image-attachments: Image attachments for chat messages via paste, drag-and-drop, and file picker. Uses ImageIO for processing, actor-based file persistence, and inline base64 thumbnails in session JSON.

--- a/Extremis/App/AppDelegate.swift
+++ b/Extremis/App/AppDelegate.swift
@@ -60,6 +60,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
             // Restore last session after provider is ready
             await restoreSessionOnLaunch()
+
+            // Cleanup orphaned images in background (non-blocking)
+            Task.detached(priority: .background) {
+                await Self.cleanupOrphanedImages()
+            }
         }
 
         print("✅ Extremis launched successfully")
@@ -73,6 +78,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         if let session = sessionManager.currentSession {
             promptWindowController.setSession(session, id: sessionManager.currentSessionId)
             print("📚 Restored session with \(session.messages.count) messages")
+        }
+    }
+
+    /// Remove orphaned image files not referenced by any session
+    private static func cleanupOrphanedImages() async {
+        do {
+            let storage = JSONSessionStorage()
+            let sessions = try await storage.listSessions()
+            var activeFilenames = Set<String>()
+
+            for entry in sessions {
+                if let persisted = try await storage.loadSession(id: entry.id) {
+                    for message in persisted.messages {
+                        if let refs = message.imageRefs {
+                            for ref in refs {
+                                activeFilenames.insert(ref.filename)
+                            }
+                        }
+                    }
+                }
+            }
+
+            let removed = try await ImagePersistence.shared.cleanupOrphaned(activeRefs: activeFilenames)
+            if removed > 0 {
+                print("[ImageCleanup] Removed \(removed) orphaned image files")
+            }
+        } catch {
+            print("[ImageCleanup] Failed: \(error)")
         }
     }
 

--- a/Extremis/Core/Models/ChatMessage.swift
+++ b/Extremis/Core/Models/ChatMessage.swift
@@ -54,6 +54,10 @@ struct ChatMessage: Identifiable, Codable, Equatable {
     /// Only populated for assistant messages that involved tool use
     let toolRounds: [ToolExecutionRoundRecord]?
 
+    /// Image attachments included with this message (only relevant for user messages)
+    /// nil for text-only messages to preserve backward compatibility
+    let imageAttachments: [ImageAttachment]?
+
     init(
         id: UUID = UUID(),
         role: ChatRole,
@@ -61,7 +65,8 @@ struct ChatMessage: Identifiable, Codable, Equatable {
         timestamp: Date = Date(),
         context: Context? = nil,
         intent: MessageIntent? = nil,
-        toolRounds: [ToolExecutionRoundRecord]? = nil
+        toolRounds: [ToolExecutionRoundRecord]? = nil,
+        imageAttachments: [ImageAttachment]? = nil
     ) {
         self.id = id
         self.role = role
@@ -70,6 +75,7 @@ struct ChatMessage: Identifiable, Codable, Equatable {
         self.context = context
         self.intent = intent
         self.toolRounds = toolRounds
+        self.imageAttachments = imageAttachments
     }
 
     /// Create a user message (for follow-up chat messages)
@@ -80,6 +86,11 @@ struct ChatMessage: Identifiable, Codable, Equatable {
     /// Create a user message with context and intent
     static func user(_ content: String, context: Context?, intent: MessageIntent = .chat) -> ChatMessage {
         ChatMessage(role: .user, content: content, context: context, intent: intent)
+    }
+
+    /// Create a user message with image attachments
+    static func user(_ content: String, context: Context?, intent: MessageIntent = .chat, imageAttachments: [ImageAttachment]?) -> ChatMessage {
+        ChatMessage(role: .user, content: content, context: context, intent: intent, imageAttachments: imageAttachments)
     }
 
     /// Create an assistant message
@@ -95,6 +106,14 @@ struct ChatMessage: Identifiable, Codable, Equatable {
     /// Create a system message
     static func system(_ content: String) -> ChatMessage {
         ChatMessage(role: .system, content: content)
+    }
+
+    // MARK: - Image Attachment Helpers
+
+    /// Whether this message has image attachments
+    var hasImages: Bool {
+        guard let images = imageAttachments else { return false }
+        return !images.isEmpty
     }
 
     // MARK: - Tool Execution Helpers

--- a/Extremis/Core/Models/Generation.swift
+++ b/Extremis/Core/Models/Generation.swift
@@ -129,11 +129,19 @@ struct ModelCapabilities: Codable, Equatable, Hashable {
     /// Whether the model supports tool/function calling
     let supportsTools: Bool
 
+    /// Whether the model supports image/vision inputs
+    let supportsVision: Bool
+
     /// Default capabilities (assumes tool support for cloud models)
-    static let `default` = ModelCapabilities(supportsTools: true)
+    static let `default` = ModelCapabilities(supportsTools: true, supportsVision: false)
 
     /// No capabilities (for models that don't support tools)
-    static let none = ModelCapabilities(supportsTools: false)
+    static let none = ModelCapabilities(supportsTools: false, supportsVision: false)
+
+    init(supportsTools: Bool, supportsVision: Bool = false) {
+        self.supportsTools = supportsTools
+        self.supportsVision = supportsVision
+    }
 }
 
 // MARK: - LLM Model
@@ -155,6 +163,12 @@ struct LLMModel: Identifiable, Codable, Equatable, Hashable {
     /// Defaults to true if capabilities not specified (most cloud models support tools)
     var supportsTools: Bool {
         capabilities?.supportsTools ?? true
+    }
+
+    /// Whether this model supports image/vision inputs
+    /// Defaults to false if capabilities not specified
+    var supportsVision: Bool {
+        capabilities?.supportsVision ?? false
     }
 
     // MARK: - Initializers

--- a/Extremis/Core/Models/ImageAttachment.swift
+++ b/Extremis/Core/Models/ImageAttachment.swift
@@ -1,0 +1,151 @@
+// MARK: - Image Attachment Models
+// Models for image attachments in chat messages
+
+import Foundation
+
+// MARK: - Image Format
+
+/// Output format for processed images
+enum ImageFormat: String, Codable, Equatable, Hashable {
+    case jpeg
+    case png
+
+    var mimeType: String {
+        switch self {
+        case .jpeg: return "image/jpeg"
+        case .png: return "image/png"
+        }
+    }
+
+    var fileExtension: String {
+        rawValue
+    }
+}
+
+// MARK: - Image Source Type
+
+/// How the image was attached to the message
+enum ImageSourceType: String, Codable, Equatable, Hashable {
+    case clipboard
+    case filePicker = "file_picker"
+    case dragAndDrop = "drag_and_drop"
+}
+
+// MARK: - Image Processing Error
+
+/// Errors that can occur during image processing
+enum ImageProcessingError: Error, Equatable, LocalizedError {
+    case unsupportedFormat
+    case inputTooLarge(Int)
+    case processingFailed(String)
+    case outputTooLarge(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedFormat:
+            return "Unsupported image format. Supported formats: PNG, JPEG, GIF, WebP, HEIC."
+        case .inputTooLarge(let size):
+            let mb = Double(size) / 1_048_576
+            return String(format: "Image too large (%.1f MB). Maximum input size is 10 MB.", mb)
+        case .processingFailed(let reason):
+            return "Image processing failed: \(reason)"
+        case .outputTooLarge(let size):
+            let mb = Double(size) / 1_048_576
+            return String(format: "Processed image too large (%.1f MB). Maximum is 4 MB.", mb)
+        }
+    }
+}
+
+// MARK: - Image Attachment
+
+/// Represents a single image attached to a chat message
+struct ImageAttachment: Identifiable, Codable, Equatable, Hashable {
+    let id: UUID
+    let imageData: Data
+    let thumbnailData: Data
+    let originalFilename: String?
+    let width: Int
+    let height: Int
+    let fileSize: Int
+    let format: ImageFormat
+    let mimeType: String
+    let sourceType: ImageSourceType
+    let createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        imageData: Data,
+        thumbnailData: Data,
+        originalFilename: String? = nil,
+        width: Int,
+        height: Int,
+        fileSize: Int,
+        format: ImageFormat,
+        mimeType: String,
+        sourceType: ImageSourceType,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.imageData = imageData
+        self.thumbnailData = thumbnailData
+        self.originalFilename = originalFilename
+        self.width = width
+        self.height = height
+        self.fileSize = fileSize
+        self.format = format
+        self.mimeType = mimeType
+        self.sourceType = sourceType
+        self.createdAt = createdAt
+    }
+
+    /// Base64-encoded image data for LLM API payloads
+    var base64EncodedData: String {
+        imageData.base64EncodedString()
+    }
+}
+
+// MARK: - Image Ref (Persistence Reference)
+
+/// Lightweight reference stored in PersistedMessage to reference images on disk
+/// Contains inline thumbnail for fast preview without file I/O
+struct ImageRef: Codable, Equatable, Hashable {
+    let id: UUID
+    let filename: String
+    let thumbnailBase64: String
+    let originalFilename: String?
+    let width: Int
+    let height: Int
+    let format: String
+
+    /// Create from an ImageAttachment (for saving)
+    init(from attachment: ImageAttachment) {
+        self.id = attachment.id
+        self.filename = "\(attachment.id.uuidString).\(attachment.format.fileExtension)"
+        self.thumbnailBase64 = attachment.thumbnailData.base64EncodedString()
+        self.originalFilename = attachment.originalFilename
+        self.width = attachment.width
+        self.height = attachment.height
+        self.format = attachment.format.rawValue
+    }
+
+    /// Direct initializer (for loading/testing)
+    init(id: UUID, filename: String, thumbnailBase64: String, originalFilename: String?, width: Int, height: Int, format: String) {
+        self.id = id
+        self.filename = filename
+        self.thumbnailBase64 = thumbnailBase64
+        self.originalFilename = originalFilename
+        self.width = width
+        self.height = height
+        self.format = format
+    }
+
+    /// Decode thumbnail data from base64
+    var thumbnailData: Data? {
+        Data(base64Encoded: thumbnailBase64)
+    }
+
+    /// Parsed image format
+    var imageFormat: ImageFormat? {
+        ImageFormat(rawValue: format)
+    }
+}

--- a/Extremis/Core/Models/Persistence/PersistedMessage.swift
+++ b/Extremis/Core/Models/Persistence/PersistedMessage.swift
@@ -13,6 +13,7 @@ struct PersistedMessage: Codable, Identifiable, Equatable {
     let timestamp: Date
     let contextData: Data?  // Encoded Context (optional, for user messages)
     let toolRoundsData: Data?  // Encoded [ToolExecutionRoundRecord] (optional, for assistant messages)
+    let imageRefs: [ImageRef]?  // Image file references (optional, for user messages with images)
 
     // MARK: - Initialization
 
@@ -22,7 +23,8 @@ struct PersistedMessage: Codable, Identifiable, Equatable {
         content: String,
         timestamp: Date = Date(),
         contextData: Data? = nil,
-        toolRoundsData: Data? = nil
+        toolRoundsData: Data? = nil,
+        imageRefs: [ImageRef]? = nil
     ) {
         self.id = id
         self.role = role
@@ -30,21 +32,25 @@ struct PersistedMessage: Codable, Identifiable, Equatable {
         self.timestamp = timestamp
         self.contextData = contextData
         self.toolRoundsData = toolRoundsData
+        self.imageRefs = imageRefs
     }
 
     // MARK: - Convenience Initializers
 
     /// Create from existing ChatMessage (context and tool rounds are embedded in message)
-    init(from message: ChatMessage) {
+    /// imageRefs can be provided when images have been saved via ImagePersistence
+    init(from message: ChatMessage, imageRefs: [ImageRef]? = nil) {
         self.id = message.id
         self.role = message.role
         self.content = message.content
         self.timestamp = message.timestamp
         self.contextData = Self.encodeContext(message.context)
         self.toolRoundsData = Self.encodeToolRounds(message.toolRounds)
+        self.imageRefs = imageRefs
     }
 
     /// Convert to ChatMessage (restores embedded context and tool rounds)
+    /// Note: imageAttachments are restored separately via ImagePersistence
     func toChatMessage() -> ChatMessage {
         ChatMessage(
             id: id,
@@ -54,6 +60,20 @@ struct PersistedMessage: Codable, Identifiable, Equatable {
             context: decodeContext(),
             intent: nil,
             toolRounds: decodeToolRounds()
+        )
+    }
+
+    /// Convert to ChatMessage with restored image attachments
+    func toChatMessage(imageAttachments: [ImageAttachment]?) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            role: role,
+            content: content,
+            timestamp: timestamp,
+            context: decodeContext(),
+            intent: nil,
+            toolRounds: decodeToolRounds(),
+            imageAttachments: imageAttachments
         )
     }
 
@@ -93,5 +113,13 @@ struct PersistedMessage: Codable, Identifiable, Equatable {
     /// Check if message has tool execution history
     var hasToolExecutions: Bool {
         toolRoundsData != nil
+    }
+
+    // MARK: - Image Helpers
+
+    /// Check if message has image references
+    var hasImages: Bool {
+        guard let refs = imageRefs else { return false }
+        return !refs.isEmpty
     }
 }

--- a/Extremis/Core/Models/Persistence/PersistedSession.swift
+++ b/Extremis/Core/Models/Persistence/PersistedSession.swift
@@ -94,7 +94,7 @@ struct PersistedSession: Codable, Identifiable, Equatable {
 // MARK: - Conversion Extensions
 
 extension PersistedSession {
-    /// Create from live ChatSession
+    /// Create from live ChatSession, saving images to disk
     /// - Parameters:
     ///   - session: The live session
     ///   - id: Existing ID (for updates) or nil (for new)
@@ -104,10 +104,22 @@ extension PersistedSession {
         _ session: ChatSession,
         id: UUID? = nil,
         currentContext: Context? = nil
-    ) -> PersistedSession {
-        // Convert messages - context is now embedded in ChatMessage
-        let persistedMessages = session.messages.map { message -> PersistedMessage in
-            PersistedMessage(from: message)
+    ) async -> PersistedSession {
+        // Convert messages - save images to disk for messages that have them
+        var persistedMessages: [PersistedMessage] = []
+        for message in session.messages {
+            if message.hasImages, let images = message.imageAttachments {
+                // Save images to disk and create refs
+                do {
+                    let refs = try await ImagePersistence.shared.save(images)
+                    persistedMessages.append(PersistedMessage(from: message, imageRefs: refs))
+                } catch {
+                    print("[PersistedSession] Failed to save images for message \(message.id): \(error)")
+                    persistedMessages.append(PersistedMessage(from: message))
+                }
+            } else {
+                persistedMessages.append(PersistedMessage(from: message))
+            }
         }
 
         return PersistedSession(
@@ -120,9 +132,9 @@ extension PersistedSession {
         )
     }
 
-    /// Convert to live ChatSession
+    /// Convert to live ChatSession, restoring images from disk
     @MainActor
-    func toSession() -> ChatSession {
+    func toSession() async -> ChatSession {
         // Extract original context from first user message
         let originalContext = firstUserMessage?.decodeContext()
 
@@ -134,9 +146,15 @@ extension PersistedSession {
             summaryCoversCount: summary?.coversMessageCount ?? 0
         )
 
-        // Restore messages with embedded context
+        // Restore messages with embedded context and images
         for message in messages {
-            session.messages.append(message.toChatMessage())
+            if message.hasImages, let refs = message.imageRefs {
+                // Restore images from disk (per-image errors are logged internally)
+                let attachments = await ImagePersistence.shared.restore(from: refs)
+                session.messages.append(message.toChatMessage(imageAttachments: attachments.isEmpty ? nil : attachments))
+            } else {
+                session.messages.append(message.toChatMessage())
+            }
         }
 
         return session

--- a/Extremis/Core/Protocols/LLMProvider.swift
+++ b/Extremis/Core/Protocols/LLMProvider.swift
@@ -23,6 +23,10 @@ protocol LLMProvider: AnyObject {
     /// Providers can override for dynamic detection (e.g., Ollama)
     var supportsTools: Bool { get async }
 
+    /// Whether the current model supports vision/image inputs
+    /// Default implementation checks currentModel.capabilities.supportsVision
+    var supportsVision: Bool { get }
+
     /// Configure the provider with an API key
     /// - Parameter apiKey: The API key to use
     /// - Throws: LLMProviderError.invalidAPIKey if key is invalid
@@ -90,6 +94,11 @@ extension LLMProvider {
         get async {
             currentModel.capabilities?.supportsTools ?? true
         }
+    }
+
+    /// Default implementation: check the model's capabilities.supportsVision flag
+    var supportsVision: Bool {
+        currentModel.capabilities?.supportsVision ?? false
     }
 }
 

--- a/Extremis/Core/Services/ImageProcessor.swift
+++ b/Extremis/Core/Services/ImageProcessor.swift
@@ -1,0 +1,230 @@
+// MARK: - Image Processor
+// Handles image resizing, compression, thumbnail generation, and format conversion
+
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
+// MARK: - Image Processor
+
+@MainActor
+final class ImageProcessor {
+    static let shared = ImageProcessor()
+
+    // MARK: - Configuration Constants
+
+    /// Maximum pixels on the longest edge after resize
+    let maxImageLongEdge: Int = 1568
+
+    /// Maximum bytes per image after processing (4MB)
+    let maxImageFileSize: Int = 4_194_304
+
+    /// Maximum bytes for input image before processing (10MB)
+    let maxInputImageSize: Int = 10_485_760
+
+    /// Maximum images per single message
+    let maxImagesPerMessage: Int = 5
+
+    /// Maximum pixels on longest edge for thumbnails
+    let thumbnailMaxSize: Int = 200
+
+    /// JPEG compression quality for full images
+    let jpegQuality: CGFloat = 0.85
+
+    /// JPEG compression quality for thumbnails
+    let thumbnailJpegQuality: CGFloat = 0.6
+
+    // MARK: - Supported Types
+
+    /// UTTypes accepted for image input
+    /// Includes .tiff since macOS pasteboard commonly provides copied images as TIFF
+    static let supportedUTTypes: [UTType] = [
+        .png, .jpeg, .gif, .webP, .heic, .tiff
+    ]
+
+    // MARK: - Public API
+
+    /// Process raw image data into an ImageAttachment
+    /// Validates, resizes, compresses, and generates thumbnail
+    func process(data: Data, sourceType: ImageSourceType, originalFilename: String? = nil) throws -> ImageAttachment {
+        // 1. Validate input size
+        guard data.count <= maxInputImageSize else {
+            throw ImageProcessingError.inputTooLarge(data.count)
+        }
+
+        // 2. Create image source
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, nil) else {
+            throw ImageProcessingError.unsupportedFormat
+        }
+
+        // 3. Validate format
+        guard let utType = CGImageSourceGetType(imageSource) as? String else {
+            throw ImageProcessingError.unsupportedFormat
+        }
+
+        let isSupported = Self.supportedUTTypes.contains { type in
+            UTType(utType)?.conforms(to: type) ?? false
+        }
+        guard isSupported else {
+            throw ImageProcessingError.unsupportedFormat
+        }
+
+        // 4. Get original dimensions
+        guard let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil) as? [CFString: Any],
+              let pixelWidth = properties[kCGImagePropertyPixelWidth] as? Int,
+              let pixelHeight = properties[kCGImagePropertyPixelHeight] as? Int else {
+            throw ImageProcessingError.processingFailed("Cannot read image dimensions")
+        }
+
+        // 5. Determine if image has alpha (use PNG) or not (use JPEG)
+        let hasAlpha = Self.imageHasAlpha(properties: properties, utType: utType)
+        let outputFormat: ImageFormat = hasAlpha ? .png : .jpeg
+
+        // 6. Resize if needed
+        let needsResize = max(pixelWidth, pixelHeight) > maxImageLongEdge
+        let (processedData, finalWidth, finalHeight) = try resizeAndCompress(
+            imageSource: imageSource,
+            originalWidth: pixelWidth,
+            originalHeight: pixelHeight,
+            maxEdge: maxImageLongEdge,
+            format: outputFormat,
+            quality: jpegQuality,
+            needsResize: needsResize
+        )
+
+        // 7. Validate output size
+        guard processedData.count <= maxImageFileSize else {
+            throw ImageProcessingError.outputTooLarge(processedData.count)
+        }
+
+        // 8. Generate thumbnail
+        let thumbnailData = generateThumbnail(
+            imageSource: imageSource,
+            maxSize: thumbnailMaxSize,
+            quality: thumbnailJpegQuality
+        ) ?? Data()
+
+        return ImageAttachment(
+            imageData: processedData,
+            thumbnailData: thumbnailData,
+            originalFilename: originalFilename,
+            width: finalWidth,
+            height: finalHeight,
+            fileSize: processedData.count,
+            format: outputFormat,
+            mimeType: outputFormat.mimeType,
+            sourceType: sourceType
+        )
+    }
+
+    // MARK: - Private Helpers
+
+    /// Resize and compress image using ImageIO (memory-efficient)
+    private func resizeAndCompress(
+        imageSource: CGImageSource,
+        originalWidth: Int,
+        originalHeight: Int,
+        maxEdge: Int,
+        format: ImageFormat,
+        quality: CGFloat,
+        needsResize: Bool
+    ) throws -> (Data, Int, Int) {
+        let finalWidth: Int
+        let finalHeight: Int
+
+        let cgImage: CGImage
+
+        if needsResize {
+            // Use CGImageSourceCreateThumbnailAtIndex for memory-efficient resize
+            let scale = Double(maxEdge) / Double(max(originalWidth, originalHeight))
+            finalWidth = Int(round(Double(originalWidth) * scale))
+            finalHeight = Int(round(Double(originalHeight) * scale))
+
+            let options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceThumbnailMaxPixelSize: maxEdge,
+                kCGImageSourceCreateThumbnailWithTransform: true
+            ]
+
+            guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options as CFDictionary) else {
+                throw ImageProcessingError.processingFailed("Failed to resize image")
+            }
+            cgImage = thumbnail
+        } else {
+            finalWidth = originalWidth
+            finalHeight = originalHeight
+
+            guard let original = CGImageSourceCreateImageAtIndex(imageSource, 0, nil) else {
+                throw ImageProcessingError.processingFailed("Failed to decode image")
+            }
+            cgImage = original
+        }
+
+        // Compress to output format
+        let outputData = try compressImage(cgImage, format: format, quality: quality)
+
+        return (outputData, finalWidth, finalHeight)
+    }
+
+    /// Generate a small thumbnail for preview
+    private func generateThumbnail(imageSource: CGImageSource, maxSize: Int, quality: CGFloat) -> Data? {
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxSize,
+            kCGImageSourceCreateThumbnailWithTransform: true
+        ]
+
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options as CFDictionary) else {
+            return nil
+        }
+
+        return try? compressImage(thumbnail, format: .jpeg, quality: quality)
+    }
+
+    /// Compress a CGImage to JPEG or PNG data
+    private func compressImage(_ image: CGImage, format: ImageFormat, quality: CGFloat) throws -> Data {
+        let data = NSMutableData()
+
+        let utType: CFString
+        switch format {
+        case .jpeg:
+            utType = UTType.jpeg.identifier as CFString
+        case .png:
+            utType = UTType.png.identifier as CFString
+        }
+
+        guard let destination = CGImageDestinationCreateWithData(data, utType, 1, nil) else {
+            throw ImageProcessingError.processingFailed("Failed to create image destination")
+        }
+
+        var options: [CFString: Any] = [:]
+        if format == .jpeg {
+            options[kCGImageDestinationLossyCompressionQuality] = quality
+        }
+
+        CGImageDestinationAddImage(destination, image, options as CFDictionary)
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw ImageProcessingError.processingFailed("Failed to finalize image compression")
+        }
+
+        return data as Data
+    }
+
+    /// Check if image has alpha channel
+    private static func imageHasAlpha(properties: [CFString: Any], utType: String) -> Bool {
+        // Check the explicit alpha property first (works for any format)
+        if let hasAlpha = properties[kCGImagePropertyHasAlpha] as? Bool {
+            return hasAlpha
+        }
+        // If property missing, assume alpha for PNG only (conservative default)
+        if UTType(utType)?.conforms(to: .png) == true {
+            return true
+        }
+        return false
+    }
+}

--- a/Extremis/Core/Services/SessionManager.swift
+++ b/Extremis/Core/Services/SessionManager.swift
@@ -106,8 +106,8 @@ final class SessionManager: ObservableObject {
                 return
             }
 
-            // Convert to live session (context is now embedded in messages)
-            let session = persisted.toSession()
+            // Convert to live session (context and images restored from persistence)
+            let session = await persisted.toSession()
             currentSession = session
             currentSessionId = activeId
             isDirty = false
@@ -227,8 +227,8 @@ final class SessionManager: ObservableObject {
         saveDebounceTask?.cancel()
 
         do {
-            // Convert to persisted format (context is embedded in messages)
-            var persisted = PersistedSession.from(
+            // Convert to persisted format (context and images saved to disk)
+            var persisted = await PersistedSession.from(
                 session,
                 id: id,
                 currentContext: currentContext
@@ -286,7 +286,7 @@ final class SessionManager: ObservableObject {
 
         Task {
             do {
-                var persisted = PersistedSession.from(
+                var persisted = await PersistedSession.from(
                     session,
                     id: id,
                     currentContext: contextToSave
@@ -376,7 +376,7 @@ final class SessionManager: ObservableObject {
             guard let persisted = try await storage.loadSession(id: id) else {
                 throw StorageError.sessionNotFound(id: id)
             }
-            session = persisted.toSession()
+            session = await persisted.toSession()
             // Cache for future retrieval
             cacheSession(session, id: id)
         }

--- a/Extremis/LLMProviders/AnthropicProvider.swift
+++ b/Extremis/LLMProviders/AnthropicProvider.swift
@@ -331,14 +331,8 @@ final class AnthropicProvider: LLMProvider {
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        // Use formatChatMessages() which handles context formatting
-        let allMessages = PromptBuilder.shared.formatChatMessages(messages: messages)
-
-        // Extract system prompt for Anthropic's separate system parameter
-        let systemPrompt = allMessages.first { $0["role"] == "system" }?["content"] ?? ""
-
-        // Filter to non-system messages (already formatted with context)
-        let anthropicMessages = allMessages.filter { $0["role"] != "system" }
+        // Format messages with image support
+        let (systemPrompt, anthropicMessages) = Self.formatAnthropicMessagesWithImages(messages: messages)
 
         let body: [String: Any] = [
             "model": currentModel.id,
@@ -358,14 +352,8 @@ final class AnthropicProvider: LLMProvider {
         request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        // Use formatChatMessages() which handles context formatting
-        let allMessages = PromptBuilder.shared.formatChatMessages(messages: messages)
-
-        // Extract system prompt for Anthropic's separate system parameter
-        let systemPrompt = allMessages.first { $0["role"] == "system" }?["content"] ?? ""
-
-        // Filter to non-system messages (already formatted with context)
-        let anthropicMessages = allMessages.filter { $0["role"] != "system" }
+        // Format messages with image support
+        let (systemPrompt, anthropicMessages) = Self.formatAnthropicMessagesWithImages(messages: messages)
 
         let body: [String: Any] = [
             "model": currentModel.id,
@@ -451,6 +439,39 @@ final class AnthropicProvider: LLMProvider {
         return request
     }
 
+    /// Format simple chat messages with image support for Anthropic (non-tool path)
+    private static func formatAnthropicMessagesWithImages(messages: [ChatMessage]) -> (systemPrompt: String, messages: [[String: Any]]) {
+        let allMessages = PromptBuilder.shared.formatChatMessages(messages: messages)
+        let systemPrompt = allMessages.first { $0["role"] == "system" }?["content"] ?? ""
+        let nonSystemMessages = allMessages.filter { $0["role"] != "system" }
+
+        var result: [[String: Any]] = []
+        var messageIndex = 0
+        for formatted in nonSystemMessages {
+            let role = formatted["role"] ?? "user"
+            let content = formatted["content"] ?? ""
+
+            if role == "user" && messageIndex < messages.count {
+                let originalMessage = messages[messageIndex]
+                if let images = originalMessage.imageAttachments, !images.isEmpty {
+                    let multimodal = PromptBuilder.shared.formatAnthropicMultimodalContent(
+                        text: content, images: images
+                    )
+                    result.append(["role": role, "content": multimodal as Any])
+                } else {
+                    result.append(["role": role, "content": content])
+                }
+                messageIndex += 1
+            } else {
+                if role == "assistant" && messageIndex < messages.count {
+                    messageIndex += 1
+                }
+                result.append(["role": role, "content": content])
+            }
+        }
+        return (systemPrompt, result)
+    }
+
     /// Format messages with tool rounds expanded inline in correct chronological order
     /// - Parameter messages: Chat messages (may contain tool rounds in assistant messages)
     /// - Returns: Tuple of (system prompt, formatted messages array) for Anthropic API
@@ -467,7 +488,15 @@ final class AnthropicProvider: LLMProvider {
                     context: message.context,
                     intent: message.intent
                 )
-                result.append(["role": "user", "content": formattedContent])
+                // Use multimodal content blocks if message has images
+                if let images = message.imageAttachments, !images.isEmpty {
+                    let content: Any = PromptBuilder.shared.formatAnthropicMultimodalContent(
+                        text: formattedContent, images: images
+                    )
+                    result.append(["role": "user", "content": content])
+                } else {
+                    result.append(["role": "user", "content": formattedContent])
+                }
 
             case .assistant:
                 if let toolRounds = message.toolRounds, !toolRounds.isEmpty {

--- a/Extremis/LLMProviders/GeminiProvider.swift
+++ b/Extremis/LLMProviders/GeminiProvider.swift
@@ -351,6 +351,7 @@ final class GeminiProvider: LLMProvider {
 
         var contents: [[String: Any]] = []
         var systemPrepended = false
+        var userMessageIndex = 0
 
         for message in allMessages {
             // Skip system messages - we'll prepend to first user message
@@ -360,18 +361,33 @@ final class GeminiProvider: LLMProvider {
 
             // Map roles: user -> user, assistant -> model
             let geminiRole = message["role"] == "user" ? "user" : "model"
-            var content = message["content"] ?? ""
+            var textContent = message["content"] ?? ""
 
             // Prepend system prompt to first user message
             if message["role"] == "user" && !systemPrepended {
                 let systemContent = allMessages.first { $0["role"] == "system" }?["content"] ?? ""
-                content = systemContent + "\n\n" + content
+                textContent = systemContent + "\n\n" + textContent
                 systemPrepended = true
+            }
+
+            // Build parts array - add image parts if user message has images
+            var parts: [[String: Any]] = []
+            if message["role"] == "user" && userMessageIndex < messages.count {
+                let originalMessage = messages[userMessageIndex]
+                if let images = originalMessage.imageAttachments, !images.isEmpty {
+                    parts.append(contentsOf: PromptBuilder.shared.formatGeminiImageParts(images: images))
+                }
+                userMessageIndex += 1
+            } else if message["role"] == "assistant" {
+                userMessageIndex += 1
+            }
+            if !textContent.isEmpty {
+                parts.append(["text": textContent])
             }
 
             contents.append([
                 "role": geminiRole,
-                "parts": [["text": content]]
+                "parts": parts
             ])
         }
 
@@ -407,9 +423,16 @@ final class GeminiProvider: LLMProvider {
                     systemPrepended = true
                 }
 
+                // Build parts - add image parts if message has images
+                var parts: [[String: Any]] = []
+                if let images = message.imageAttachments, !images.isEmpty {
+                    parts.append(contentsOf: PromptBuilder.shared.formatGeminiImageParts(images: images))
+                }
+                parts.append(["text": formattedContent])
+
                 contents.append([
                     "role": "user",
-                    "parts": [["text": formattedContent]]
+                    "parts": parts
                 ])
 
             case .assistant:

--- a/Extremis/LLMProviders/OllamaProvider.swift
+++ b/Extremis/LLMProviders/OllamaProvider.swift
@@ -21,8 +21,9 @@ final class OllamaProvider: LLMProvider, ObservableObject {
     /// Cached list of available models from Ollama server
     private(set) var availableModelsFromServer: [LLMModel] = []
 
-    /// Cache of model tool support status (modelId -> supportsTools)
+    /// Cache of model capability status (modelId -> capabilities)
     private var toolCapabilityCache: [String: Bool] = [:]
+    private var visionCapabilityCache: [String: Bool] = [:]
 
     /// Ollama doesn't require API key, just server connectivity
     var isConfigured: Bool { serverConnected }
@@ -65,6 +66,8 @@ final class OllamaProvider: LLMProvider, ObservableObject {
         self.currentModel = model
         UserDefaults.standard.set(model.id, forKey: "ollama_model")
         print("✅ Ollama model set to: \(model.name)")
+        // Pre-detect capabilities for the new model
+        Task { await detectCapabilities(for: model.id) }
     }
 
     /// Generate from a raw prompt (already built, no additional processing)
@@ -304,26 +307,51 @@ final class OllamaProvider: LLMProvider, ObservableObject {
                 return cached
             }
 
-            // Query Ollama for model capabilities
-            let supports = await detectToolSupport(for: currentModel.id)
-            toolCapabilityCache[currentModel.id] = supports
-            return supports
+            // Query Ollama for model capabilities (caches both tools and vision)
+            await detectCapabilities(for: currentModel.id)
+            return toolCapabilityCache[currentModel.id] ?? false
         }
     }
 
-    /// Query Ollama's /api/show endpoint for model capabilities
-    /// Returns true if the model's capabilities include "tools"
-    private func detectToolSupport(for modelId: String) async -> Bool {
-        guard serverConnected else { return false }
+    /// Override: Check if the current model supports vision via /api/show
+    var supportsVision: Bool {
+        // Check cache first — if not cached, default to false (async detection happens via supportsTools)
+        if let cached = visionCapabilityCache[currentModel.id] {
+            return cached
+        }
+        // Trigger async detection in the background so it's ready for next check
+        Task { await detectCapabilities(for: currentModel.id) }
+        return false
+    }
 
-        guard let url = URL(string: "\(baseURL)/api/show") else { return false }
+    /// Query Ollama's /api/show endpoint for model capabilities
+    /// Caches both tool and vision support for the given model
+    private func detectCapabilities(for modelId: String) async {
+        // Skip if already cached
+        if toolCapabilityCache[modelId] != nil { return }
+
+        guard serverConnected else {
+            toolCapabilityCache[modelId] = false
+            visionCapabilityCache[modelId] = false
+            return
+        }
+
+        guard let url = URL(string: "\(baseURL)/api/show") else {
+            toolCapabilityCache[modelId] = false
+            visionCapabilityCache[modelId] = false
+            return
+        }
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
         let body = ["name": modelId]
-        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return false }
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else {
+            toolCapabilityCache[modelId] = false
+            visionCapabilityCache[modelId] = false
+            return
+        }
         request.httpBody = bodyData
 
         do {
@@ -334,22 +362,29 @@ final class OllamaProvider: LLMProvider, ObservableObject {
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let capabilities = json["capabilities"] as? [String] {
                 let supportsTools = capabilities.contains("tools")
-                print("🔧 Ollama model '\(modelId)' capabilities: \(capabilities), supportsTools: \(supportsTools)")
-                return supportsTools
+                let supportsVision = capabilities.contains("vision")
+                toolCapabilityCache[modelId] = supportsTools
+                visionCapabilityCache[modelId] = supportsVision
+                print("🔧 Ollama model '\(modelId)' capabilities: \(capabilities), supportsTools: \(supportsTools), supportsVision: \(supportsVision)")
+                return
             }
 
-            // If capabilities field is missing (older Ollama version), assume no tool support
-            print("⚠️ Ollama model '\(modelId)' has no capabilities field - assuming no tool support")
-            return false
+            // If capabilities field is missing (older Ollama version), assume no support
+            print("⚠️ Ollama model '\(modelId)' has no capabilities field - assuming no tool/vision support")
+            toolCapabilityCache[modelId] = false
+            visionCapabilityCache[modelId] = false
+            return
         } catch {
-            print("⚠️ Failed to detect tool support for '\(modelId)': \(error.localizedDescription)")
-            return false // Conservative: assume no support on error
+            print("⚠️ Failed to detect capabilities for '\(modelId)': \(error.localizedDescription)")
+            toolCapabilityCache[modelId] = false
+            visionCapabilityCache[modelId] = false
         }
     }
 
     /// Clear capability cache (called on server reconnect)
     func clearCapabilityCache() {
         toolCapabilityCache.removeAll()
+        visionCapabilityCache.removeAll()
         print("🔧 Cleared Ollama tool capability cache")
     }
 
@@ -413,6 +448,9 @@ final class OllamaProvider: LLMProvider, ObservableObject {
             }
 
             print("✅ Ollama models loaded: \(availableModelsFromServer.map { $0.id }), current: \(currentModel.id)")
+
+            // Pre-detect capabilities for the current model so supportsVision is ready synchronously
+            await detectCapabilities(for: currentModel.id)
         } catch {
             print("⚠️ Failed to fetch Ollama models: \(error.localizedDescription)")
             availableModelsFromServer = []
@@ -458,7 +496,7 @@ final class OllamaProvider: LLMProvider, ObservableObject {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let formattedMessages = PromptBuilder.shared.formatChatMessages(messages: messages)
+        let formattedMessages = Self.formatOllamaMessagesWithImages(messages: messages)
         let body: [String: Any] = [
             "model": currentModel.id,
             "messages": formattedMessages,
@@ -474,7 +512,7 @@ final class OllamaProvider: LLMProvider, ObservableObject {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let formattedMessages = PromptBuilder.shared.formatChatMessages(messages: messages)
+        let formattedMessages = Self.formatOllamaMessagesWithImages(messages: messages)
         let body: [String: Any] = [
             "model": currentModel.id,
             "messages": formattedMessages,
@@ -564,6 +602,34 @@ final class OllamaProvider: LLMProvider, ObservableObject {
         return request
     }
 
+    /// Format simple chat messages with image support for Ollama (non-tool path)
+    /// Ollama uses a separate "images" array field with raw base64 (no data URI prefix)
+    private static func formatOllamaMessagesWithImages(messages: [ChatMessage]) -> [[String: Any]] {
+        let textMessages = PromptBuilder.shared.formatChatMessages(messages: messages)
+        var result: [[String: Any]] = []
+
+        var messageIndex = 0
+        for formatted in textMessages {
+            let role = formatted["role"] ?? "user"
+            let content = formatted["content"] ?? ""
+
+            var msg: [String: Any] = ["role": role, "content": content]
+
+            if role == "user" && messageIndex < messages.count {
+                let originalMessage = messages[messageIndex]
+                if let images = originalMessage.imageAttachments, !images.isEmpty {
+                    msg["images"] = PromptBuilder.shared.formatOllamaImages(images: images)
+                }
+                messageIndex += 1
+            } else if role == "assistant" {
+                messageIndex += 1
+            }
+
+            result.append(msg)
+        }
+        return result
+    }
+
     /// Format messages with tool rounds expanded inline in correct chronological order
     /// - Parameter messages: Chat messages (may contain tool rounds in assistant messages)
     /// - Returns: Formatted messages array for OpenAI-compatible API
@@ -583,7 +649,12 @@ final class OllamaProvider: LLMProvider, ObservableObject {
                     context: message.context,
                     intent: message.intent
                 )
-                result.append(["role": "user", "content": formattedContent])
+                // Add images array if message has images (Ollama format)
+                var msg: [String: Any] = ["role": "user", "content": formattedContent]
+                if let images = message.imageAttachments, !images.isEmpty {
+                    msg["images"] = PromptBuilder.shared.formatOllamaImages(images: images)
+                }
+                result.append(msg)
 
             case .assistant:
                 if let toolRounds = message.toolRounds, !toolRounds.isEmpty {

--- a/Extremis/LLMProviders/OpenAIProvider.swift
+++ b/Extremis/LLMProviders/OpenAIProvider.swift
@@ -322,7 +322,7 @@ final class OpenAIProvider: LLMProvider {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let formattedMessages = PromptBuilder.shared.formatChatMessages(messages: messages)
+        let formattedMessages = Self.formatMessagesWithImages(messages: messages)
         let body: [String: Any] = [
             "model": currentModel.id,
             "messages": formattedMessages,
@@ -339,7 +339,7 @@ final class OpenAIProvider: LLMProvider {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let formattedMessages = PromptBuilder.shared.formatChatMessages(messages: messages)
+        let formattedMessages = Self.formatMessagesWithImages(messages: messages)
         let body: [String: Any] = [
             "model": currentModel.id,
             "messages": formattedMessages,
@@ -466,6 +466,43 @@ final class OpenAIProvider: LLMProvider {
         return request
     }
 
+    /// Format simple chat messages with image support (non-tool path)
+    /// Converts [[String: String]] to [[String: Any]] with multimodal content blocks where needed
+    private static func formatMessagesWithImages(messages: [ChatMessage]) -> [[String: Any]] {
+        let textMessages = PromptBuilder.shared.formatChatMessages(messages: messages)
+        var result: [[String: Any]] = []
+
+        // Map original ChatMessages to their formatted versions, injecting images
+        var messageIndex = 0
+        for formatted in textMessages {
+            let role = formatted["role"] ?? "user"
+            let content = formatted["content"] ?? ""
+
+            if role == "user" && messageIndex < messages.count {
+                // Find matching user message to check for images
+                let originalMessage = messages[messageIndex]
+                if let images = originalMessage.imageAttachments, !images.isEmpty {
+                    let multimodal = PromptBuilder.shared.formatOpenAIMultimodalContent(
+                        text: content, images: images
+                    )
+                    result.append(["role": role, "content": multimodal as Any])
+                } else {
+                    result.append(["role": role, "content": content])
+                }
+                messageIndex += 1
+            } else if role == "system" {
+                result.append(["role": role, "content": content])
+            } else {
+                if role == "assistant" && messageIndex < messages.count {
+                    messageIndex += 1
+                }
+                result.append(["role": role, "content": content])
+            }
+        }
+
+        return result
+    }
+
     /// Format messages with tool rounds expanded inline in correct chronological order
     /// - Parameter messages: Chat messages (may contain tool rounds in assistant messages)
     /// - Returns: Formatted messages array for OpenAI API
@@ -486,7 +523,15 @@ final class OpenAIProvider: LLMProvider {
                     context: message.context,
                     intent: message.intent
                 )
-                result.append(["role": "user", "content": formattedContent])
+                // Use multimodal content blocks if message has images
+                if let images = message.imageAttachments, !images.isEmpty {
+                    let content: Any = PromptBuilder.shared.formatOpenAIMultimodalContent(
+                        text: formattedContent, images: images
+                    )
+                    result.append(["role": "user", "content": content])
+                } else {
+                    result.append(["role": "user", "content": formattedContent])
+                }
 
             case .assistant:
                 if let toolRounds = message.toolRounds, !toolRounds.isEmpty {

--- a/Extremis/LLMProviders/PromptBuilder.swift
+++ b/Extremis/LLMProviders/PromptBuilder.swift
@@ -180,6 +180,58 @@ final class PromptBuilder {
         return result
     }
 
+    // MARK: - Multimodal Content Formatting
+
+    /// Format a user message's content as multimodal content blocks for OpenAI-style APIs
+    /// Returns nil if the message has no images (caller should use plain string content)
+    func formatOpenAIMultimodalContent(text: String, images: [ImageAttachment]) -> [[String: Any]] {
+        var content: [[String: Any]] = []
+        for image in images {
+            content.append([
+                "type": "image_url",
+                "image_url": [
+                    "url": "data:\(image.mimeType);base64,\(image.base64EncodedData)",
+                    "detail": "auto"
+                ]
+            ])
+        }
+        if !text.isEmpty {
+            content.append(["type": "text", "text": text])
+        }
+        return content
+    }
+
+    /// Format a user message's content as multimodal content blocks for Anthropic API
+    func formatAnthropicMultimodalContent(text: String, images: [ImageAttachment]) -> [[String: Any]] {
+        var content: [[String: Any]] = []
+        for image in images {
+            content.append([
+                "type": "image",
+                "source": [
+                    "type": "base64",
+                    "media_type": image.mimeType,
+                    "data": image.base64EncodedData
+                ]
+            ])
+        }
+        if !text.isEmpty {
+            content.append(["type": "text", "text": text])
+        }
+        return content
+    }
+
+    /// Format image parts for Gemini API
+    func formatGeminiImageParts(images: [ImageAttachment]) -> [[String: Any]] {
+        images.map { image in
+            ["inlineData": ["mimeType": image.mimeType, "data": image.base64EncodedData]]
+        }
+    }
+
+    /// Format Ollama images array (raw base64, no data URI prefix)
+    func formatOllamaImages(images: [ImageAttachment]) -> [String] {
+        images.map { $0.base64EncodedData }
+    }
+
     /// Log full chat messages being sent (controlled by debugLogging flag)
     private func logChatMessages(_ messages: [[String: String]]) {
         guard debugLogging else { return }

--- a/Extremis/Resources/models.json
+++ b/Extremis/Resources/models.json
@@ -3,29 +3,28 @@
   "providers": {
     "openai": {
       "models": [
-        {"id": "gpt-4o", "name": "GPT-4o", "description": "Most capable, multimodal", "capabilities": {"supportsTools": true}},
-        {"id": "gpt-4o-mini", "name": "GPT-4o Mini", "description": "Fast and affordable", "capabilities": {"supportsTools": true}},
-        {"id": "gpt-4-turbo", "name": "GPT-4 Turbo", "description": "Powerful with vision", "capabilities": {"supportsTools": true}},
-        {"id": "gpt-4", "name": "GPT-4", "description": "Original GPT-4", "capabilities": {"supportsTools": true}}
+        {"id": "gpt-4o", "name": "GPT-4o", "description": "Most capable, multimodal", "capabilities": {"supportsTools": true, "supportsVision": true}},
+        {"id": "gpt-4o-mini", "name": "GPT-4o Mini", "description": "Fast and affordable", "capabilities": {"supportsTools": true, "supportsVision": true}},
+        {"id": "gpt-4-turbo", "name": "GPT-4 Turbo", "description": "Powerful with vision", "capabilities": {"supportsTools": true, "supportsVision": true}},
+        {"id": "gpt-4", "name": "GPT-4", "description": "Original GPT-4", "capabilities": {"supportsTools": true, "supportsVision": false}}
       ],
       "default": "gpt-4o"
     },
     "anthropic": {
       "models": [
-        {"id": "claude-sonnet-4-5-20250929", "name": "Claude Sonnet 4.5", "description": "Smart model for complex agents and coding", "capabilities": {"supportsTools": true}},
-        {"id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5", "description": "Fastest model with near-frontier intelligence", "capabilities": {"supportsTools": true}},
-        {"id": "claude-opus-4-5-20251101", "name": "Claude Opus 4.5", "description": "Premium model combining maximum intelligence with practical performance", "capabilities": {"supportsTools": true}}
+        {"id": "claude-sonnet-4-5-20250929", "name": "Claude Sonnet 4.5", "description": "Smart model for complex agents and coding", "capabilities": {"supportsTools": true, "supportsVision": true}},
+        {"id": "claude-haiku-4-5-20251001", "name": "Claude Haiku 4.5", "description": "Fastest model with near-frontier intelligence", "capabilities": {"supportsTools": true, "supportsVision": true}},
+        {"id": "claude-opus-4-5-20251101", "name": "Claude Opus 4.5", "description": "Premium model combining maximum intelligence with practical performance", "capabilities": {"supportsTools": true, "supportsVision": true}}
       ],
       "default": "claude-sonnet-4-5-20250929"
     },
     "gemini": {
       "models": [
-        {"id": "gemini-3-flash-preview", "name": "Gemini 3 flash preview", "description": "Latest, fastest", "capabilities": {"supportsTools": true}},
-        {"id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash", "description": "Fast and capable", "capabilities": {"supportsTools": false}},
-        {"id": "gemini-2.0-flash", "name": "Gemini 2.0 Flash", "description": "Fast and versatile", "capabilities": {"supportsTools": true}}
+        {"id": "gemini-3-flash-preview", "name": "Gemini 3 flash preview", "description": "Latest, fastest", "capabilities": {"supportsTools": true, "supportsVision": true}},
+        {"id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash", "description": "Fast and capable", "capabilities": {"supportsTools": false, "supportsVision": true}},
+        {"id": "gemini-2.0-flash", "name": "Gemini 2.0 Flash", "description": "Fast and versatile", "capabilities": {"supportsTools": true, "supportsVision": true}}
       ],
       "default": "gemini-3-flash-preview"
     }
   }
 }
-

--- a/Extremis/Tests/Core/ImageAttachmentTests.swift
+++ b/Extremis/Tests/Core/ImageAttachmentTests.swift
@@ -1,0 +1,587 @@
+// MARK: - ImageAttachment Model Tests
+// Tests for ImageAttachment, ImageRef, ImageFormat, ImageSourceType
+
+import Foundation
+
+// MARK: - Test Runner
+
+struct TestRunner {
+    static var passedCount = 0
+    static var failedCount = 0
+    static var failedTests: [(name: String, message: String)] = []
+
+    static func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ testName: String) {
+        if actual == expected {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected '\(expected)' but got '\(actual)'"))
+            print("  ✗ \(testName): Expected '\(expected)' but got '\(actual)'")
+        }
+    }
+
+    static func assertTrue(_ condition: Bool, _ testName: String) {
+        if condition {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected true but got false"))
+            print("  ✗ \(testName): Expected true but got false")
+        }
+    }
+
+    static func assertFalse(_ condition: Bool, _ testName: String) {
+        assertTrue(!condition, testName)
+    }
+
+    static func assertNotNil<T>(_ value: T?, _ testName: String) {
+        if value != nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected non-nil but got nil"))
+            print("  ✗ \(testName): Expected non-nil but got nil")
+        }
+    }
+
+    static func assertNil<T>(_ value: T?, _ testName: String) {
+        if value == nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected nil but got \(value!)"))
+            print("  ✗ \(testName): Expected nil but got \(value!)")
+        }
+    }
+
+    static func suite(_ name: String) {
+        print("\n📋 \(name)")
+        print("--------------------------------------------------")
+    }
+
+    static func printSummary() {
+        print("\n==================================================")
+        print("TEST SUMMARY")
+        print("==================================================")
+        print("Passed: \(passedCount)")
+        print("Failed: \(failedCount)")
+        print("Total:  \(passedCount + failedCount)")
+        print("==================================================")
+        if !failedTests.isEmpty {
+            print("\nFailed tests:")
+            for test in failedTests {
+                print("  ✗ \(test.name): \(test.message)")
+            }
+        }
+    }
+}
+
+// MARK: - Inline Type Definitions (for standalone compilation)
+
+enum ImageFormat: String, Codable, Equatable, Hashable {
+    case jpeg
+    case png
+
+    var mimeType: String {
+        switch self {
+        case .jpeg: return "image/jpeg"
+        case .png: return "image/png"
+        }
+    }
+
+    var fileExtension: String {
+        rawValue
+    }
+}
+
+enum ImageSourceType: String, Codable, Equatable, Hashable {
+    case clipboard
+    case filePicker = "file_picker"
+    case dragAndDrop = "drag_and_drop"
+}
+
+struct ImageAttachment: Identifiable, Codable, Equatable, Hashable {
+    let id: UUID
+    let imageData: Data
+    let thumbnailData: Data
+    let originalFilename: String?
+    let width: Int
+    let height: Int
+    let fileSize: Int
+    let format: ImageFormat
+    let mimeType: String
+    let sourceType: ImageSourceType
+    let createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        imageData: Data,
+        thumbnailData: Data,
+        originalFilename: String? = nil,
+        width: Int,
+        height: Int,
+        fileSize: Int,
+        format: ImageFormat,
+        mimeType: String,
+        sourceType: ImageSourceType,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.imageData = imageData
+        self.thumbnailData = thumbnailData
+        self.originalFilename = originalFilename
+        self.width = width
+        self.height = height
+        self.fileSize = fileSize
+        self.format = format
+        self.mimeType = mimeType
+        self.sourceType = sourceType
+        self.createdAt = createdAt
+    }
+
+    var base64EncodedData: String {
+        imageData.base64EncodedString()
+    }
+}
+
+struct ImageRef: Codable, Equatable {
+    let id: UUID
+    let filename: String
+    let thumbnailBase64: String
+    let originalFilename: String?
+    let width: Int
+    let height: Int
+    let format: String
+
+    init(from attachment: ImageAttachment) {
+        self.id = attachment.id
+        self.filename = "\(attachment.id.uuidString).\(attachment.format.rawValue)"
+        self.thumbnailBase64 = attachment.thumbnailData.base64EncodedString()
+        self.originalFilename = attachment.originalFilename
+        self.width = attachment.width
+        self.height = attachment.height
+        self.format = attachment.format.rawValue
+    }
+
+    init(id: UUID, filename: String, thumbnailBase64: String, originalFilename: String?, width: Int, height: Int, format: String) {
+        self.id = id
+        self.filename = filename
+        self.thumbnailBase64 = thumbnailBase64
+        self.originalFilename = originalFilename
+        self.width = width
+        self.height = height
+        self.format = format
+    }
+
+    var thumbnailData: Data? {
+        Data(base64Encoded: thumbnailBase64)
+    }
+
+    var imageFormat: ImageFormat? {
+        ImageFormat(rawValue: format)
+    }
+}
+
+// MARK: - Tests
+
+func testImageFormatEnum() {
+    TestRunner.suite("ImageFormat Enum")
+
+    TestRunner.assertEqual(ImageFormat.jpeg.rawValue, "jpeg", "JPEG raw value")
+    TestRunner.assertEqual(ImageFormat.png.rawValue, "png", "PNG raw value")
+    TestRunner.assertEqual(ImageFormat.jpeg.mimeType, "image/jpeg", "JPEG mime type")
+    TestRunner.assertEqual(ImageFormat.png.mimeType, "image/png", "PNG mime type")
+
+    // Codable round-trip
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    if let data = try? encoder.encode(ImageFormat.jpeg),
+       let decoded = try? decoder.decode(ImageFormat.self, from: data) {
+        TestRunner.assertEqual(decoded, ImageFormat.jpeg, "ImageFormat Codable round-trip JPEG")
+    } else {
+        TestRunner.assertTrue(false, "ImageFormat Codable round-trip JPEG")
+    }
+    if let data = try? encoder.encode(ImageFormat.png),
+       let decoded = try? decoder.decode(ImageFormat.self, from: data) {
+        TestRunner.assertEqual(decoded, ImageFormat.png, "ImageFormat Codable round-trip PNG")
+    } else {
+        TestRunner.assertTrue(false, "ImageFormat Codable round-trip PNG")
+    }
+}
+
+func testImageSourceTypeEnum() {
+    TestRunner.suite("ImageSourceType Enum")
+
+    TestRunner.assertEqual(ImageSourceType.clipboard.rawValue, "clipboard", "Clipboard raw value")
+    TestRunner.assertEqual(ImageSourceType.filePicker.rawValue, "file_picker", "File picker raw value")
+    TestRunner.assertEqual(ImageSourceType.dragAndDrop.rawValue, "drag_and_drop", "Drag and drop raw value")
+
+    // Codable round-trip
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    for sourceType in [ImageSourceType.clipboard, .filePicker, .dragAndDrop] {
+        if let data = try? encoder.encode(sourceType),
+           let decoded = try? decoder.decode(ImageSourceType.self, from: data) {
+            TestRunner.assertEqual(decoded, sourceType, "ImageSourceType Codable round-trip \(sourceType.rawValue)")
+        } else {
+            TestRunner.assertTrue(false, "ImageSourceType Codable round-trip \(sourceType.rawValue)")
+        }
+    }
+}
+
+func testImageAttachmentCodable() {
+    TestRunner.suite("ImageAttachment Codable")
+
+    let imageData = Data(repeating: 0xFF, count: 100)
+    let thumbData = Data(repeating: 0xAA, count: 50)
+    let id = UUID()
+    let date = Date(timeIntervalSince1970: 1700000000)
+
+    let attachment = ImageAttachment(
+        id: id,
+        imageData: imageData,
+        thumbnailData: thumbData,
+        originalFilename: "test.jpg",
+        width: 800,
+        height: 600,
+        fileSize: 100,
+        format: .jpeg,
+        mimeType: "image/jpeg",
+        sourceType: .clipboard,
+        createdAt: date
+    )
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    if let data = try? encoder.encode(attachment),
+       let decoded = try? decoder.decode(ImageAttachment.self, from: data) {
+        TestRunner.assertEqual(decoded.id, id, "Codable round-trip preserves id")
+        TestRunner.assertEqual(decoded.imageData, imageData, "Codable round-trip preserves imageData")
+        TestRunner.assertEqual(decoded.thumbnailData, thumbData, "Codable round-trip preserves thumbnailData")
+        TestRunner.assertEqual(decoded.originalFilename, "test.jpg", "Codable round-trip preserves originalFilename")
+        TestRunner.assertEqual(decoded.width, 800, "Codable round-trip preserves width")
+        TestRunner.assertEqual(decoded.height, 600, "Codable round-trip preserves height")
+        TestRunner.assertEqual(decoded.fileSize, 100, "Codable round-trip preserves fileSize")
+        TestRunner.assertEqual(decoded.format, .jpeg, "Codable round-trip preserves format")
+        TestRunner.assertEqual(decoded.mimeType, "image/jpeg", "Codable round-trip preserves mimeType")
+        TestRunner.assertEqual(decoded.sourceType, .clipboard, "Codable round-trip preserves sourceType")
+    } else {
+        TestRunner.assertTrue(false, "ImageAttachment Codable encoding/decoding failed")
+    }
+}
+
+func testImageAttachmentEquatable() {
+    TestRunner.suite("ImageAttachment Equatable")
+
+    let id = UUID()
+    let imageData = Data(repeating: 0xFF, count: 100)
+    let thumbData = Data(repeating: 0xAA, count: 50)
+    let date = Date()
+
+    let a = ImageAttachment(id: id, imageData: imageData, thumbnailData: thumbData,
+                            width: 800, height: 600, fileSize: 100,
+                            format: .jpeg, mimeType: "image/jpeg", sourceType: .clipboard, createdAt: date)
+    let b = ImageAttachment(id: id, imageData: imageData, thumbnailData: thumbData,
+                            width: 800, height: 600, fileSize: 100,
+                            format: .jpeg, mimeType: "image/jpeg", sourceType: .clipboard, createdAt: date)
+    let c = ImageAttachment(id: UUID(), imageData: imageData, thumbnailData: thumbData,
+                            width: 800, height: 600, fileSize: 100,
+                            format: .jpeg, mimeType: "image/jpeg", sourceType: .clipboard, createdAt: date)
+
+    TestRunner.assertTrue(a == b, "Same fields are equal")
+    TestRunner.assertFalse(a == c, "Different IDs are not equal")
+}
+
+func testImageAttachmentNilFilename() {
+    TestRunner.suite("ImageAttachment Nil Filename")
+
+    let attachment = ImageAttachment(
+        imageData: Data(repeating: 0xFF, count: 10),
+        thumbnailData: Data(repeating: 0xAA, count: 5),
+        originalFilename: nil,
+        width: 100, height: 100, fileSize: 10,
+        format: .png, mimeType: "image/png", sourceType: .clipboard
+    )
+
+    TestRunner.assertNil(attachment.originalFilename, "Clipboard paste has nil filename")
+
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    encoder.dateEncodingStrategy = .iso8601
+    decoder.dateDecodingStrategy = .iso8601
+
+    if let data = try? encoder.encode(attachment),
+       let decoded = try? decoder.decode(ImageAttachment.self, from: data) {
+        TestRunner.assertNil(decoded.originalFilename, "Nil filename survives Codable round-trip")
+    } else {
+        TestRunner.assertTrue(false, "Nil filename Codable round-trip failed")
+    }
+}
+
+func testImageRefFromAttachment() {
+    TestRunner.suite("ImageRef from ImageAttachment")
+
+    let id = UUID()
+    let thumbData = Data(repeating: 0xBB, count: 20)
+    let attachment = ImageAttachment(
+        id: id,
+        imageData: Data(repeating: 0xFF, count: 100),
+        thumbnailData: thumbData,
+        originalFilename: "screenshot.png",
+        width: 1024, height: 768, fileSize: 100,
+        format: .png, mimeType: "image/png", sourceType: .filePicker
+    )
+
+    let ref = ImageRef(from: attachment)
+
+    TestRunner.assertEqual(ref.id, id, "ImageRef id matches attachment")
+    TestRunner.assertEqual(ref.filename, "\(id.uuidString).png", "ImageRef filename has correct format")
+    TestRunner.assertEqual(ref.thumbnailBase64, thumbData.base64EncodedString(), "ImageRef thumbnail is base64 encoded")
+    TestRunner.assertEqual(ref.originalFilename, "screenshot.png", "ImageRef preserves originalFilename")
+    TestRunner.assertEqual(ref.width, 1024, "ImageRef preserves width")
+    TestRunner.assertEqual(ref.height, 768, "ImageRef preserves height")
+    TestRunner.assertEqual(ref.format, "png", "ImageRef format is raw string")
+}
+
+func testImageRefCodable() {
+    TestRunner.suite("ImageRef Codable")
+
+    let ref = ImageRef(
+        id: UUID(),
+        filename: "test.jpg",
+        thumbnailBase64: "base64data",
+        originalFilename: "photo.jpg",
+        width: 640, height: 480,
+        format: "jpeg"
+    )
+
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+
+    if let data = try? encoder.encode(ref),
+       let decoded = try? decoder.decode(ImageRef.self, from: data) {
+        TestRunner.assertEqual(decoded.id, ref.id, "ImageRef Codable round-trip id")
+        TestRunner.assertEqual(decoded.filename, "test.jpg", "ImageRef Codable round-trip filename")
+        TestRunner.assertEqual(decoded.thumbnailBase64, "base64data", "ImageRef Codable round-trip thumbnail")
+        TestRunner.assertEqual(decoded.originalFilename, "photo.jpg", "ImageRef Codable round-trip originalFilename")
+        TestRunner.assertEqual(decoded.width, 640, "ImageRef Codable round-trip width")
+        TestRunner.assertEqual(decoded.height, 480, "ImageRef Codable round-trip height")
+        TestRunner.assertEqual(decoded.format, "jpeg", "ImageRef Codable round-trip format")
+    } else {
+        TestRunner.assertTrue(false, "ImageRef Codable encoding/decoding failed")
+    }
+}
+
+func testImageRefNilOriginalFilename() {
+    TestRunner.suite("ImageRef Nil Original Filename")
+
+    let ref = ImageRef(
+        id: UUID(), filename: "test.jpg", thumbnailBase64: "data",
+        originalFilename: nil, width: 100, height: 100, format: "jpeg"
+    )
+
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+
+    if let data = try? encoder.encode(ref),
+       let decoded = try? decoder.decode(ImageRef.self, from: data) {
+        TestRunner.assertNil(decoded.originalFilename, "Nil originalFilename survives Codable round-trip")
+    } else {
+        TestRunner.assertTrue(false, "ImageRef nil originalFilename round-trip failed")
+    }
+}
+
+// MARK: - ImageRef Computed Properties Tests
+
+func testImageRefThumbnailData() {
+    TestRunner.suite("ImageRef thumbnailData Computed Property")
+
+    // Valid base64
+    let originalData = Data([0xDE, 0xAD, 0xBE, 0xEF])
+    let ref = ImageRef(
+        id: UUID(), filename: "test.jpg",
+        thumbnailBase64: originalData.base64EncodedString(),
+        originalFilename: nil, width: 100, height: 100, format: "jpeg"
+    )
+    if let decoded = ref.thumbnailData {
+        TestRunner.assertEqual(decoded, originalData, "thumbnailData decodes correctly from valid base64")
+    } else {
+        TestRunner.assertTrue(false, "thumbnailData should not be nil for valid base64")
+    }
+
+    // Invalid base64
+    let badRef = ImageRef(
+        id: UUID(), filename: "test.jpg",
+        thumbnailBase64: "!!!not-base64!!!",
+        originalFilename: nil, width: 100, height: 100, format: "jpeg"
+    )
+    TestRunner.assertNil(badRef.thumbnailData, "thumbnailData is nil for invalid base64")
+
+    // Empty base64
+    let emptyRef = ImageRef(
+        id: UUID(), filename: "test.jpg",
+        thumbnailBase64: "",
+        originalFilename: nil, width: 100, height: 100, format: "jpeg"
+    )
+    if let decoded = emptyRef.thumbnailData {
+        TestRunner.assertEqual(decoded, Data(), "Empty base64 decodes to empty Data")
+    } else {
+        TestRunner.assertTrue(false, "Empty base64 should decode to empty Data")
+    }
+}
+
+func testImageRefImageFormat() {
+    TestRunner.suite("ImageRef imageFormat Computed Property")
+
+    let jpegRef = ImageRef(
+        id: UUID(), filename: "test.jpg", thumbnailBase64: "",
+        originalFilename: nil, width: 100, height: 100, format: "jpeg"
+    )
+    TestRunner.assertEqual(jpegRef.imageFormat, ImageFormat.jpeg, "imageFormat parses jpeg")
+
+    let pngRef = ImageRef(
+        id: UUID(), filename: "test.png", thumbnailBase64: "",
+        originalFilename: nil, width: 100, height: 100, format: "png"
+    )
+    TestRunner.assertEqual(pngRef.imageFormat, ImageFormat.png, "imageFormat parses png")
+
+    let unknownRef = ImageRef(
+        id: UUID(), filename: "test.bmp", thumbnailBase64: "",
+        originalFilename: nil, width: 100, height: 100, format: "bmp"
+    )
+    TestRunner.assertNil(unknownRef.imageFormat, "imageFormat returns nil for unknown format")
+
+    let emptyRef = ImageRef(
+        id: UUID(), filename: "test", thumbnailBase64: "",
+        originalFilename: nil, width: 100, height: 100, format: ""
+    )
+    TestRunner.assertNil(emptyRef.imageFormat, "imageFormat returns nil for empty format string")
+}
+
+// MARK: - ImageFormat fileExtension Tests
+
+func testImageFormatFileExtension() {
+    TestRunner.suite("ImageFormat fileExtension")
+
+    TestRunner.assertEqual(ImageFormat.jpeg.fileExtension, "jpeg", "JPEG file extension")
+    TestRunner.assertEqual(ImageFormat.png.fileExtension, "png", "PNG file extension")
+}
+
+// MARK: - ImageRef filename format Tests
+
+func testImageRefFilenameFormat() {
+    TestRunner.suite("ImageRef Filename Format")
+
+    let id = UUID()
+    let jpegAttachment = ImageAttachment(
+        id: id, imageData: Data([0xFF]), thumbnailData: Data([0xAA]),
+        width: 100, height: 100, fileSize: 1,
+        format: .jpeg, mimeType: "image/jpeg", sourceType: .clipboard
+    )
+    let jpegRef = ImageRef(from: jpegAttachment)
+    TestRunner.assertEqual(jpegRef.filename, "\(id.uuidString).jpeg", "JPEG ref filename has .jpeg extension")
+
+    let pngAttachment = ImageAttachment(
+        id: id, imageData: Data([0xFF]), thumbnailData: Data([0xAA]),
+        width: 100, height: 100, fileSize: 1,
+        format: .png, mimeType: "image/png", sourceType: .filePicker
+    )
+    let pngRef = ImageRef(from: pngAttachment)
+    TestRunner.assertEqual(pngRef.filename, "\(id.uuidString).png", "PNG ref filename has .png extension")
+}
+
+// MARK: - ImageAttachment base64EncodedData Tests
+
+func testImageAttachmentBase64EncodedData() {
+    TestRunner.suite("ImageAttachment base64EncodedData")
+
+    let imageData = Data([0xDE, 0xAD, 0xBE, 0xEF])
+    let attachment = ImageAttachment(
+        imageData: imageData, thumbnailData: Data(),
+        width: 10, height: 10, fileSize: 4,
+        format: .jpeg, mimeType: "image/jpeg", sourceType: .clipboard
+    )
+
+    TestRunner.assertEqual(attachment.base64EncodedData, imageData.base64EncodedString(),
+                           "base64EncodedData matches direct base64 encoding")
+
+    // Empty data
+    let emptyAttachment = ImageAttachment(
+        imageData: Data(), thumbnailData: Data(),
+        width: 0, height: 0, fileSize: 0,
+        format: .png, mimeType: "image/png", sourceType: .clipboard
+    )
+    TestRunner.assertEqual(emptyAttachment.base64EncodedData, "", "Empty imageData produces empty base64")
+}
+
+// MARK: - ImageAttachment Hashable Tests
+
+func testImageAttachmentHashable() {
+    TestRunner.suite("ImageAttachment Hashable")
+
+    let id = UUID()
+    let date = Date()
+    let a = ImageAttachment(
+        id: id, imageData: Data([0xFF]), thumbnailData: Data([0xAA]),
+        width: 100, height: 100, fileSize: 1,
+        format: .jpeg, mimeType: "image/jpeg", sourceType: .clipboard, createdAt: date
+    )
+    let b = ImageAttachment(
+        id: id, imageData: Data([0xFF]), thumbnailData: Data([0xAA]),
+        width: 100, height: 100, fileSize: 1,
+        format: .jpeg, mimeType: "image/jpeg", sourceType: .clipboard, createdAt: date
+    )
+
+    // Same objects should produce same hash
+    TestRunner.assertEqual(a.hashValue, b.hashValue, "Equal attachments have equal hash values")
+
+    // Can be used in a Set
+    var set = Set<ImageAttachment>()
+    set.insert(a)
+    set.insert(b)
+    TestRunner.assertEqual(set.count, 1, "Set deduplicates equal attachments")
+
+    // Different attachment
+    let c = ImageAttachment(
+        id: UUID(), imageData: Data([0xFF]), thumbnailData: Data([0xAA]),
+        width: 100, height: 100, fileSize: 1,
+        format: .jpeg, mimeType: "image/jpeg", sourceType: .clipboard
+    )
+    set.insert(c)
+    TestRunner.assertEqual(set.count, 2, "Set keeps distinct attachments")
+}
+
+// MARK: - Entry Point
+
+@main
+struct ImageAttachmentTests {
+    static func main() {
+        print("🧪 ImageAttachment Model Tests")
+        print("==================================================")
+
+        testImageFormatEnum()
+        testImageSourceTypeEnum()
+        testImageAttachmentCodable()
+        testImageAttachmentEquatable()
+        testImageAttachmentNilFilename()
+        testImageRefFromAttachment()
+        testImageRefCodable()
+        testImageRefNilOriginalFilename()
+        testImageRefThumbnailData()
+        testImageRefImageFormat()
+        testImageFormatFileExtension()
+        testImageRefFilenameFormat()
+        testImageAttachmentBase64EncodedData()
+        testImageAttachmentHashable()
+
+        TestRunner.printSummary()
+        if TestRunner.failedCount > 0 { exit(1) }
+    }
+}

--- a/Extremis/Tests/Core/ImageProcessorTests.swift
+++ b/Extremis/Tests/Core/ImageProcessorTests.swift
@@ -1,0 +1,280 @@
+// MARK: - ImageProcessor Tests
+// Tests for image format validation, size validation, and processing logic
+
+import Foundation
+
+// MARK: - Test Runner
+
+struct TestRunner {
+    static var passedCount = 0
+    static var failedCount = 0
+    static var failedTests: [(name: String, message: String)] = []
+
+    static func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ testName: String) {
+        if actual == expected {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected '\(expected)' but got '\(actual)'"))
+            print("  ✗ \(testName): Expected '\(expected)' but got '\(actual)'")
+        }
+    }
+
+    static func assertTrue(_ condition: Bool, _ testName: String) {
+        if condition {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected true but got false"))
+            print("  ✗ \(testName): Expected true but got false")
+        }
+    }
+
+    static func assertFalse(_ condition: Bool, _ testName: String) {
+        assertTrue(!condition, testName)
+    }
+
+    static func suite(_ name: String) {
+        print("\n📋 \(name)")
+        print("--------------------------------------------------")
+    }
+
+    static func printSummary() {
+        print("\n==================================================")
+        print("TEST SUMMARY")
+        print("==================================================")
+        print("Passed: \(passedCount)")
+        print("Failed: \(failedCount)")
+        print("Total:  \(passedCount + failedCount)")
+        print("==================================================")
+        if !failedTests.isEmpty {
+            print("\nFailed tests:")
+            for test in failedTests {
+                print("  ✗ \(test.name): \(test.message)")
+            }
+        }
+    }
+}
+
+// MARK: - Inline Type Definitions
+
+enum ImageFormat: String, Codable, Equatable {
+    case jpeg, png
+    var mimeType: String {
+        switch self {
+        case .jpeg: return "image/jpeg"
+        case .png: return "image/png"
+        }
+    }
+}
+
+enum ImageSourceType: String, Codable, Equatable {
+    case clipboard, filePicker = "file_picker", dragAndDrop = "drag_and_drop"
+}
+
+enum ImageProcessingError: Error, Equatable {
+    case unsupportedFormat
+    case inputTooLarge(Int)
+    case processingFailed(String)
+    case outputTooLarge(Int)
+}
+
+struct ImageProcessorConfig {
+    let maxImageLongEdge: Int = 1568
+    let maxImageFileSize: Int = 4_194_304
+    let maxInputImageSize: Int = 10_485_760
+    let maxImagesPerMessage: Int = 5
+    let thumbnailMaxSize: Int = 200
+    let jpegQuality: Double = 0.85
+    let thumbnailJpegQuality: Double = 0.6
+}
+
+// MARK: - Tests
+
+func testConfigurationConstants() {
+    TestRunner.suite("Configuration Constants")
+
+    let config = ImageProcessorConfig()
+    TestRunner.assertEqual(config.maxImageLongEdge, 1568, "Max long edge is 1568px")
+    TestRunner.assertEqual(config.maxImageFileSize, 4_194_304, "Max file size is 4MB")
+    TestRunner.assertEqual(config.maxInputImageSize, 10_485_760, "Max input size is 10MB")
+    TestRunner.assertEqual(config.maxImagesPerMessage, 5, "Max images per message is 5")
+    TestRunner.assertEqual(config.thumbnailMaxSize, 200, "Thumbnail max size is 200px")
+    TestRunner.assertTrue(config.jpegQuality == 0.85, "JPEG quality is 0.85")
+    TestRunner.assertTrue(config.thumbnailJpegQuality == 0.6, "Thumbnail JPEG quality is 0.6")
+}
+
+func testInputSizeValidation() {
+    TestRunner.suite("Input Size Validation")
+
+    let maxInput = 10_485_760 // 10MB
+
+    // Under limit
+    let smallData = Data(repeating: 0xFF, count: 1024)
+    TestRunner.assertTrue(smallData.count <= maxInput, "1KB data is under 10MB limit")
+
+    // At limit
+    let atLimit = Data(repeating: 0xFF, count: maxInput)
+    TestRunner.assertTrue(atLimit.count <= maxInput, "Exactly 10MB is at limit")
+
+    // Over limit
+    let overLimit = Data(repeating: 0xFF, count: maxInput + 1)
+    TestRunner.assertTrue(overLimit.count > maxInput, "10MB + 1 byte exceeds limit")
+}
+
+func testBase64Encoding() {
+    TestRunner.suite("Base64 Encoding")
+
+    let testData = Data([0x48, 0x65, 0x6C, 0x6C, 0x6F]) // "Hello"
+    let base64 = testData.base64EncodedString()
+    TestRunner.assertEqual(base64, "SGVsbG8=", "Base64 encodes correctly")
+
+    // Round-trip
+    if let decoded = Data(base64Encoded: base64) {
+        TestRunner.assertEqual(decoded, testData, "Base64 round-trip preserves data")
+    } else {
+        TestRunner.assertTrue(false, "Base64 decoding failed")
+    }
+
+    // Empty data
+    let emptyBase64 = Data().base64EncodedString()
+    TestRunner.assertEqual(emptyBase64, "", "Empty data produces empty base64")
+}
+
+func testImageProcessingErrorEquatable() {
+    TestRunner.suite("ImageProcessingError Equatable")
+
+    TestRunner.assertTrue(
+        ImageProcessingError.unsupportedFormat == ImageProcessingError.unsupportedFormat,
+        "Same unsupportedFormat are equal"
+    )
+    TestRunner.assertTrue(
+        ImageProcessingError.inputTooLarge(100) == ImageProcessingError.inputTooLarge(100),
+        "Same inputTooLarge values are equal"
+    )
+    TestRunner.assertFalse(
+        ImageProcessingError.inputTooLarge(100) == ImageProcessingError.inputTooLarge(200),
+        "Different inputTooLarge values are not equal"
+    )
+    TestRunner.assertFalse(
+        ImageProcessingError.unsupportedFormat == ImageProcessingError.inputTooLarge(100),
+        "Different error types are not equal"
+    )
+}
+
+func testDimensionCalculation() {
+    TestRunner.suite("Dimension Calculation (resize logic)")
+
+    let maxEdge = 1568
+
+    // Landscape image that needs resize
+    let w1 = 3000, h1 = 2000
+    let scale1 = Double(maxEdge) / Double(max(w1, h1))
+    let newW1 = Int(Double(w1) * scale1)
+    let newH1 = Int(Double(h1) * scale1)
+    TestRunner.assertTrue(newW1 <= maxEdge, "Resized landscape width <= 1568")
+    TestRunner.assertTrue(newH1 <= maxEdge, "Resized landscape height <= 1568")
+    TestRunner.assertTrue(newW1 >= 1567 && newW1 <= 1568, "Landscape width scaled to ~1568")
+    TestRunner.assertEqual(newH1, 1045, "Landscape height proportionally scaled")
+
+    // Portrait image that needs resize
+    let w2 = 1000, h2 = 4000
+    let scale2 = Double(maxEdge) / Double(max(w2, h2))
+    let newW2 = Int(Double(w2) * scale2)
+    let newH2 = Int(Double(h2) * scale2)
+    TestRunner.assertTrue(newW2 <= maxEdge, "Resized portrait width <= 1568")
+    TestRunner.assertEqual(newH2, 1568, "Portrait height scaled to 1568")
+
+    // Image that doesn't need resize
+    let w3 = 800, h3 = 600
+    let needsResize = max(w3, h3) > maxEdge
+    TestRunner.assertFalse(needsResize, "800x600 does not need resize")
+
+    // Square image at exact limit
+    let w4 = 1568, h4 = 1568
+    let needsResize4 = max(w4, h4) > maxEdge
+    TestRunner.assertFalse(needsResize4, "1568x1568 does not need resize")
+}
+
+func testThumbnailDimensionCalculation() {
+    TestRunner.suite("Thumbnail Dimension Calculation")
+
+    let maxThumb = 200
+
+    // Large landscape
+    let w1 = 1568, h1 = 1045
+    let scale1 = Double(maxThumb) / Double(max(w1, h1))
+    let thumbW1 = Int(Double(w1) * scale1)
+    let thumbH1 = Int(Double(h1) * scale1)
+    TestRunner.assertTrue(thumbW1 <= maxThumb, "Thumbnail width <= 200")
+    TestRunner.assertTrue(thumbH1 <= maxThumb, "Thumbnail height <= 200")
+    TestRunner.assertEqual(thumbW1, 200, "Thumbnail landscape width = 200")
+
+    // Small image (no resize needed for thumbnail)
+    let w2 = 100, h2 = 80
+    let needsThumbResize = max(w2, h2) > maxThumb
+    TestRunner.assertFalse(needsThumbResize, "100x80 does not need thumbnail resize")
+}
+
+func testFormatDetectionLogic() {
+    TestRunner.suite("Format Detection Logic")
+
+    // PNG magic bytes
+    let pngHeader: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+    let pngData = Data(pngHeader)
+    TestRunner.assertTrue(pngData.count >= 8, "PNG header has at least 8 bytes")
+    TestRunner.assertEqual(pngData[0], 0x89, "PNG starts with 0x89")
+    TestRunner.assertEqual(pngData[1], 0x50, "PNG byte 1 is 0x50 (P)")
+
+    // JPEG magic bytes
+    let jpegHeader: [UInt8] = [0xFF, 0xD8, 0xFF]
+    let jpegData = Data(jpegHeader)
+    TestRunner.assertEqual(jpegData[0], 0xFF, "JPEG starts with 0xFF")
+    TestRunner.assertEqual(jpegData[1], 0xD8, "JPEG byte 1 is 0xD8")
+
+    // GIF magic bytes
+    let gif87Header = Data("GIF87a".utf8)
+    let gif89Header = Data("GIF89a".utf8)
+    TestRunner.assertTrue(gif87Header.starts(with: Data("GIF".utf8)), "GIF87a starts with GIF")
+    TestRunner.assertTrue(gif89Header.starts(with: Data("GIF".utf8)), "GIF89a starts with GIF")
+}
+
+func testOutputFormatSelection() {
+    TestRunner.suite("Output Format Selection")
+
+    // Photos without transparency -> JPEG
+    let photoFormat: ImageFormat = .jpeg
+    TestRunner.assertEqual(photoFormat, .jpeg, "Photos use JPEG format")
+
+    // Images with transparency -> PNG
+    let transparentFormat: ImageFormat = .png
+    TestRunner.assertEqual(transparentFormat, .png, "Transparent images use PNG format")
+
+    // MIME types
+    TestRunner.assertEqual(ImageFormat.jpeg.mimeType, "image/jpeg", "JPEG MIME type")
+    TestRunner.assertEqual(ImageFormat.png.mimeType, "image/png", "PNG MIME type")
+}
+
+// MARK: - Entry Point
+
+@main
+struct ImageProcessorTests {
+    static func main() {
+        print("🧪 ImageProcessor Tests")
+        print("==================================================")
+
+        testConfigurationConstants()
+        testInputSizeValidation()
+        testBase64Encoding()
+        testImageProcessingErrorEquatable()
+        testDimensionCalculation()
+        testThumbnailDimensionCalculation()
+        testFormatDetectionLogic()
+        testOutputFormatSelection()
+
+        TestRunner.printSummary()
+        if TestRunner.failedCount > 0 { exit(1) }
+    }
+}

--- a/Extremis/Tests/LLMProviders/PromptBuilderImageTests.swift
+++ b/Extremis/Tests/LLMProviders/PromptBuilderImageTests.swift
@@ -1,0 +1,385 @@
+// MARK: - PromptBuilder Multimodal Formatting Tests
+// Tests for multimodal message formatting across all providers
+
+import Foundation
+
+// MARK: - Test Runner
+
+struct TestRunner {
+    static var passedCount = 0
+    static var failedCount = 0
+    static var failedTests: [(name: String, message: String)] = []
+
+    static func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ testName: String) {
+        if actual == expected {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected '\(expected)' but got '\(actual)'"))
+            print("  ✗ \(testName): Expected '\(expected)' but got '\(actual)'")
+        }
+    }
+
+    static func assertTrue(_ condition: Bool, _ testName: String) {
+        if condition {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected true but got false"))
+            print("  ✗ \(testName): Expected true but got false")
+        }
+    }
+
+    static func assertFalse(_ condition: Bool, _ testName: String) {
+        assertTrue(!condition, testName)
+    }
+
+    static func assertNotNil<T>(_ value: T?, _ testName: String) {
+        if value != nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected non-nil but got nil"))
+            print("  ✗ \(testName): Expected non-nil but got nil")
+        }
+    }
+
+    static func suite(_ name: String) {
+        print("\n📋 \(name)")
+        print("--------------------------------------------------")
+    }
+
+    static func printSummary() {
+        print("\n==================================================")
+        print("TEST SUMMARY")
+        print("==================================================")
+        print("Passed: \(passedCount)")
+        print("Failed: \(failedCount)")
+        print("Total:  \(passedCount + failedCount)")
+        print("==================================================")
+        if !failedTests.isEmpty {
+            print("\nFailed tests:")
+            for test in failedTests {
+                print("  ✗ \(test.name): \(test.message)")
+            }
+        }
+    }
+}
+
+// MARK: - Inline Type Definitions
+
+enum ImageFormat: String, Codable, Equatable {
+    case jpeg, png
+    var mimeType: String {
+        switch self {
+        case .jpeg: return "image/jpeg"
+        case .png: return "image/png"
+        }
+    }
+}
+
+enum ImageSourceType: String, Codable, Equatable {
+    case clipboard, filePicker = "file_picker", dragAndDrop = "drag_and_drop"
+}
+
+struct ImageAttachment: Identifiable, Codable, Equatable {
+    let id: UUID
+    let imageData: Data
+    let thumbnailData: Data
+    let originalFilename: String?
+    let width: Int
+    let height: Int
+    let fileSize: Int
+    let format: ImageFormat
+    let mimeType: String
+    let sourceType: ImageSourceType
+    let createdAt: Date
+
+    init(id: UUID = UUID(), imageData: Data, thumbnailData: Data, originalFilename: String? = nil,
+         width: Int, height: Int, fileSize: Int, format: ImageFormat, mimeType: String,
+         sourceType: ImageSourceType, createdAt: Date = Date()) {
+        self.id = id; self.imageData = imageData; self.thumbnailData = thumbnailData
+        self.originalFilename = originalFilename; self.width = width; self.height = height
+        self.fileSize = fileSize; self.format = format; self.mimeType = mimeType
+        self.sourceType = sourceType; self.createdAt = createdAt
+    }
+}
+
+// MARK: - Multimodal Formatting Functions (standalone test implementations)
+
+func formatOpenAIContent(text: String, images: [ImageAttachment]) -> [[String: Any]] {
+    var content: [[String: Any]] = []
+    for image in images {
+        let base64 = image.imageData.base64EncodedString()
+        content.append([
+            "type": "image_url",
+            "image_url": ["url": "data:\(image.mimeType);base64,\(base64)", "detail": "auto"]
+        ])
+    }
+    if !text.isEmpty {
+        content.append(["type": "text", "text": text])
+    }
+    return content
+}
+
+func formatAnthropicContent(text: String, images: [ImageAttachment]) -> [[String: Any]] {
+    var content: [[String: Any]] = []
+    for image in images {
+        let base64 = image.imageData.base64EncodedString()
+        content.append([
+            "type": "image",
+            "source": ["type": "base64", "media_type": image.mimeType, "data": base64]
+        ])
+    }
+    if !text.isEmpty {
+        content.append(["type": "text", "text": text])
+    }
+    return content
+}
+
+func formatGeminiParts(text: String, images: [ImageAttachment]) -> [[String: Any]] {
+    var parts: [[String: Any]] = []
+    for image in images {
+        let base64 = image.imageData.base64EncodedString()
+        parts.append(["inlineData": ["mimeType": image.mimeType, "data": base64]])
+    }
+    if !text.isEmpty {
+        parts.append(["text": text])
+    }
+    return parts
+}
+
+func formatOllamaMessage(text: String, images: [ImageAttachment]) -> [String: Any] {
+    var msg: [String: Any] = ["role": "user", "content": text]
+    if !images.isEmpty {
+        msg["images"] = images.map { $0.imageData.base64EncodedString() }
+    }
+    return msg
+}
+
+// MARK: - Helper
+
+func makeTestAttachment(format: ImageFormat = .jpeg) -> ImageAttachment {
+    ImageAttachment(
+        imageData: Data([0xFF, 0xD8, 0xFF, 0xE0]),
+        thumbnailData: Data([0xAA, 0xBB]),
+        width: 800, height: 600, fileSize: 4,
+        format: format,
+        mimeType: format.mimeType,
+        sourceType: .clipboard
+    )
+}
+
+// MARK: - Tests
+
+func testTextOnlyMessageUnchanged() {
+    TestRunner.suite("Text-Only Messages Unchanged")
+
+    let text = "Hello, how are you?"
+    let images: [ImageAttachment] = []
+
+    // OpenAI: when no images, should just use string content
+    TestRunner.assertTrue(images.isEmpty, "No images means text-only message")
+    TestRunner.assertFalse(text.isEmpty, "Text content exists")
+}
+
+func testOpenAIVisionFormat() {
+    TestRunner.suite("OpenAI Vision Format")
+
+    let image = makeTestAttachment()
+    let content = formatOpenAIContent(text: "What is this?", images: [image])
+
+    TestRunner.assertEqual(content.count, 2, "OpenAI content has 2 blocks (1 image + 1 text)")
+
+    // First block should be image
+    let imageBlock = content[0]
+    TestRunner.assertEqual(imageBlock["type"] as? String, "image_url", "First block type is image_url")
+    if let imageUrl = imageBlock["image_url"] as? [String: String] {
+        TestRunner.assertTrue(imageUrl["url"]?.hasPrefix("data:image/jpeg;base64,") ?? false, "URL has data URI prefix")
+        TestRunner.assertEqual(imageUrl["detail"], "auto", "Detail is auto")
+    } else {
+        TestRunner.assertTrue(false, "image_url dict missing")
+    }
+
+    // Second block should be text
+    let textBlock = content[1]
+    TestRunner.assertEqual(textBlock["type"] as? String, "text", "Second block type is text")
+    TestRunner.assertEqual(textBlock["text"] as? String, "What is this?", "Text content preserved")
+}
+
+func testAnthropicMultimodalFormat() {
+    TestRunner.suite("Anthropic Multimodal Format")
+
+    let image = makeTestAttachment()
+    let content = formatAnthropicContent(text: "Describe this", images: [image])
+
+    TestRunner.assertEqual(content.count, 2, "Anthropic content has 2 blocks")
+
+    let imageBlock = content[0]
+    TestRunner.assertEqual(imageBlock["type"] as? String, "image", "First block type is image")
+    if let source = imageBlock["source"] as? [String: String] {
+        TestRunner.assertEqual(source["type"], "base64", "Source type is base64")
+        TestRunner.assertEqual(source["media_type"], "image/jpeg", "Media type is image/jpeg")
+        TestRunner.assertNotNil(source["data"], "Base64 data present")
+    } else {
+        TestRunner.assertTrue(false, "source dict missing")
+    }
+
+    let textBlock = content[1]
+    TestRunner.assertEqual(textBlock["type"] as? String, "text", "Second block type is text")
+}
+
+func testGeminiInlineDataFormat() {
+    TestRunner.suite("Gemini InlineData Format")
+
+    let image = makeTestAttachment()
+    let parts = formatGeminiParts(text: "What's this?", images: [image])
+
+    TestRunner.assertEqual(parts.count, 2, "Gemini parts has 2 entries")
+
+    let imagePart = parts[0]
+    if let inlineData = imagePart["inlineData"] as? [String: String] {
+        TestRunner.assertEqual(inlineData["mimeType"], "image/jpeg", "Gemini mimeType correct")
+        TestRunner.assertNotNil(inlineData["data"], "Gemini base64 data present")
+    } else {
+        TestRunner.assertTrue(false, "inlineData dict missing")
+    }
+
+    let textPart = parts[1]
+    TestRunner.assertEqual(textPart["text"] as? String, "What's this?", "Gemini text part correct")
+}
+
+func testOllamaImagesArrayFormat() {
+    TestRunner.suite("Ollama Images Array Format")
+
+    let image = makeTestAttachment()
+    let msg = formatOllamaMessage(text: "Describe", images: [image])
+
+    TestRunner.assertEqual(msg["role"] as? String, "user", "Ollama role is user")
+    TestRunner.assertEqual(msg["content"] as? String, "Describe", "Ollama content is plain text")
+
+    if let images = msg["images"] as? [String] {
+        TestRunner.assertEqual(images.count, 1, "Ollama has 1 image in array")
+        TestRunner.assertFalse(images[0].hasPrefix("data:"), "Ollama base64 has no data URI prefix")
+    } else {
+        TestRunner.assertTrue(false, "Ollama images array missing")
+    }
+}
+
+func testImageOnlyMessage() {
+    TestRunner.suite("Image-Only Message (No Text)")
+
+    let image = makeTestAttachment()
+
+    // OpenAI: image only
+    let openaiContent = formatOpenAIContent(text: "", images: [image])
+    TestRunner.assertEqual(openaiContent.count, 1, "OpenAI image-only has 1 block")
+    TestRunner.assertEqual(openaiContent[0]["type"] as? String, "image_url", "OpenAI image-only block is image_url")
+
+    // Anthropic: image only
+    let anthropicContent = formatAnthropicContent(text: "", images: [image])
+    TestRunner.assertEqual(anthropicContent.count, 1, "Anthropic image-only has 1 block")
+
+    // Gemini: image only
+    let geminiParts = formatGeminiParts(text: "", images: [image])
+    TestRunner.assertEqual(geminiParts.count, 1, "Gemini image-only has 1 part")
+
+    // Ollama: image with empty text
+    let ollamaMsg = formatOllamaMessage(text: "", images: [image])
+    TestRunner.assertEqual(ollamaMsg["content"] as? String, "", "Ollama content is empty string")
+    TestRunner.assertNotNil(ollamaMsg["images"], "Ollama still has images array")
+}
+
+func testMultipleImagesPerMessage() {
+    TestRunner.suite("Multiple Images Per Message")
+
+    let images = [makeTestAttachment(), makeTestAttachment(format: .png), makeTestAttachment()]
+
+    // OpenAI
+    let openaiContent = formatOpenAIContent(text: "Compare these", images: images)
+    TestRunner.assertEqual(openaiContent.count, 4, "OpenAI: 3 images + 1 text = 4 blocks")
+
+    // Anthropic
+    let anthropicContent = formatAnthropicContent(text: "Compare", images: images)
+    TestRunner.assertEqual(anthropicContent.count, 4, "Anthropic: 3 images + 1 text = 4 blocks")
+
+    // Gemini
+    let geminiParts = formatGeminiParts(text: "Compare", images: images)
+    TestRunner.assertEqual(geminiParts.count, 4, "Gemini: 3 images + 1 text = 4 parts")
+
+    // Ollama
+    let ollamaMsg = formatOllamaMessage(text: "Compare", images: images)
+    if let imgs = ollamaMsg["images"] as? [String] {
+        TestRunner.assertEqual(imgs.count, 3, "Ollama: 3 images in array")
+    } else {
+        TestRunner.assertTrue(false, "Ollama images array missing for multiple images")
+    }
+}
+
+func testPNGFormatInContent() {
+    TestRunner.suite("PNG Format in Content Blocks")
+
+    let image = makeTestAttachment(format: .png)
+
+    let openaiContent = formatOpenAIContent(text: "Test", images: [image])
+    if let imageUrl = (openaiContent[0]["image_url"] as? [String: String]) {
+        TestRunner.assertTrue(imageUrl["url"]?.contains("image/png") ?? false, "OpenAI uses image/png for PNG")
+    }
+
+    let anthropicContent = formatAnthropicContent(text: "Test", images: [image])
+    if let source = (anthropicContent[0]["source"] as? [String: String]) {
+        TestRunner.assertEqual(source["media_type"], "image/png", "Anthropic uses image/png for PNG")
+    }
+
+    let geminiParts = formatGeminiParts(text: "Test", images: [image])
+    if let inlineData = (geminiParts[0]["inlineData"] as? [String: String]) {
+        TestRunner.assertEqual(inlineData["mimeType"], "image/png", "Gemini uses image/png for PNG")
+    }
+}
+
+func testImagesBeforeText() {
+    TestRunner.suite("Images Placed Before Text")
+
+    let image = makeTestAttachment()
+
+    // OpenAI
+    let openai = formatOpenAIContent(text: "Text", images: [image])
+    TestRunner.assertEqual(openai[0]["type"] as? String, "image_url", "OpenAI: image before text")
+    TestRunner.assertEqual(openai[1]["type"] as? String, "text", "OpenAI: text after image")
+
+    // Anthropic
+    let anthropic = formatAnthropicContent(text: "Text", images: [image])
+    TestRunner.assertEqual(anthropic[0]["type"] as? String, "image", "Anthropic: image before text")
+    TestRunner.assertEqual(anthropic[1]["type"] as? String, "text", "Anthropic: text after image")
+
+    // Gemini
+    let gemini = formatGeminiParts(text: "Text", images: [image])
+    TestRunner.assertNotNil(gemini[0]["inlineData"], "Gemini: inlineData before text")
+    TestRunner.assertNotNil(gemini[1]["text"], "Gemini: text after inlineData")
+}
+
+// MARK: - Entry Point
+
+@main
+struct PromptBuilderImageTests {
+    static func main() {
+        print("🧪 PromptBuilder Multimodal Formatting Tests")
+        print("==================================================")
+
+        testTextOnlyMessageUnchanged()
+        testOpenAIVisionFormat()
+        testAnthropicMultimodalFormat()
+        testGeminiInlineDataFormat()
+        testOllamaImagesArrayFormat()
+        testImageOnlyMessage()
+        testMultipleImagesPerMessage()
+        testPNGFormatInContent()
+        testImagesBeforeText()
+
+        TestRunner.printSummary()
+        if TestRunner.failedCount > 0 { exit(1) }
+    }
+}

--- a/Extremis/Tests/Utilities/ImagePersistenceTests.swift
+++ b/Extremis/Tests/Utilities/ImagePersistenceTests.swift
@@ -1,0 +1,341 @@
+// MARK: - ImagePersistence Tests
+// Tests for save/load round-trip, restore from ImageRef, delete, file naming, missing file handling
+
+import Foundation
+
+// MARK: - Test Runner
+
+struct TestRunner {
+    static var passedCount = 0
+    static var failedCount = 0
+    static var failedTests: [(name: String, message: String)] = []
+
+    static func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ testName: String) {
+        if actual == expected {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected '\(expected)' but got '\(actual)'"))
+            print("  ✗ \(testName): Expected '\(expected)' but got '\(actual)'")
+        }
+    }
+
+    static func assertTrue(_ condition: Bool, _ testName: String) {
+        if condition {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected true but got false"))
+            print("  ✗ \(testName): Expected true but got false")
+        }
+    }
+
+    static func assertFalse(_ condition: Bool, _ testName: String) {
+        assertTrue(!condition, testName)
+    }
+
+    static func assertNotNil<T>(_ value: T?, _ testName: String) {
+        if value != nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected non-nil but got nil"))
+            print("  ✗ \(testName): Expected non-nil but got nil")
+        }
+    }
+
+    static func assertNil<T>(_ value: T?, _ testName: String) {
+        if value == nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected nil but got value"))
+            print("  ✗ \(testName): Expected nil but got value")
+        }
+    }
+
+    static func suite(_ name: String) {
+        print("\n📋 \(name)")
+        print("--------------------------------------------------")
+    }
+
+    static func printSummary() {
+        print("\n==================================================")
+        print("TEST SUMMARY")
+        print("==================================================")
+        print("Passed: \(passedCount)")
+        print("Failed: \(failedCount)")
+        print("Total:  \(passedCount + failedCount)")
+        print("==================================================")
+        if !failedTests.isEmpty {
+            print("\nFailed tests:")
+            for test in failedTests {
+                print("  ✗ \(test.name): \(test.message)")
+            }
+        }
+    }
+}
+
+// MARK: - Inline Type Definitions
+
+enum ImageFormat: String, Codable, Equatable {
+    case jpeg, png
+    var mimeType: String {
+        switch self {
+        case .jpeg: return "image/jpeg"
+        case .png: return "image/png"
+        }
+    }
+}
+
+enum ImageSourceType: String, Codable, Equatable {
+    case clipboard, filePicker = "file_picker", dragAndDrop = "drag_and_drop"
+}
+
+struct ImageAttachment: Identifiable, Codable, Equatable {
+    let id: UUID
+    let imageData: Data
+    let thumbnailData: Data
+    let originalFilename: String?
+    let width: Int
+    let height: Int
+    let fileSize: Int
+    let format: ImageFormat
+    let mimeType: String
+    let sourceType: ImageSourceType
+    let createdAt: Date
+
+    init(id: UUID = UUID(), imageData: Data, thumbnailData: Data, originalFilename: String? = nil,
+         width: Int, height: Int, fileSize: Int, format: ImageFormat, mimeType: String,
+         sourceType: ImageSourceType, createdAt: Date = Date()) {
+        self.id = id; self.imageData = imageData; self.thumbnailData = thumbnailData
+        self.originalFilename = originalFilename; self.width = width; self.height = height
+        self.fileSize = fileSize; self.format = format; self.mimeType = mimeType
+        self.sourceType = sourceType; self.createdAt = createdAt
+    }
+}
+
+struct ImageRef: Codable, Equatable {
+    let id: UUID
+    let filename: String
+    let thumbnailBase64: String
+    let originalFilename: String?
+    let width: Int
+    let height: Int
+    let format: String
+
+    init(from attachment: ImageAttachment) {
+        self.id = attachment.id
+        self.filename = "\(attachment.id.uuidString).\(attachment.format.rawValue)"
+        self.thumbnailBase64 = attachment.thumbnailData.base64EncodedString()
+        self.originalFilename = attachment.originalFilename
+        self.width = attachment.width
+        self.height = attachment.height
+        self.format = attachment.format.rawValue
+    }
+
+    init(id: UUID, filename: String, thumbnailBase64: String, originalFilename: String?, width: Int, height: Int, format: String) {
+        self.id = id; self.filename = filename; self.thumbnailBase64 = thumbnailBase64
+        self.originalFilename = originalFilename; self.width = width; self.height = height; self.format = format
+    }
+}
+
+// MARK: - Tests
+
+func testFileNamingConvention() {
+    TestRunner.suite("File Naming Convention")
+
+    let id = UUID()
+    let attachment = ImageAttachment(
+        id: id, imageData: Data(repeating: 0xFF, count: 10), thumbnailData: Data(repeating: 0xAA, count: 5),
+        width: 100, height: 100, fileSize: 10, format: .jpeg, mimeType: "image/jpeg", sourceType: .clipboard
+    )
+    let ref = ImageRef(from: attachment)
+
+    TestRunner.assertEqual(ref.filename, "\(id.uuidString).jpeg", "JPEG filename follows {uuid}.jpeg convention")
+
+    let pngAttachment = ImageAttachment(
+        id: id, imageData: Data(repeating: 0xFF, count: 10), thumbnailData: Data(repeating: 0xAA, count: 5),
+        width: 100, height: 100, fileSize: 10, format: .png, mimeType: "image/png", sourceType: .filePicker
+    )
+    let pngRef = ImageRef(from: pngAttachment)
+    TestRunner.assertEqual(pngRef.filename, "\(id.uuidString).png", "PNG filename follows {uuid}.png convention")
+}
+
+func testImageRefPreservesMetadata() {
+    TestRunner.suite("ImageRef Preserves Metadata")
+
+    let id = UUID()
+    let thumbData = Data(repeating: 0xBB, count: 30)
+    let attachment = ImageAttachment(
+        id: id, imageData: Data(repeating: 0xFF, count: 100), thumbnailData: thumbData,
+        originalFilename: "photo.jpg", width: 1024, height: 768, fileSize: 100,
+        format: .jpeg, mimeType: "image/jpeg", sourceType: .dragAndDrop
+    )
+    let ref = ImageRef(from: attachment)
+
+    TestRunner.assertEqual(ref.id, id, "ID preserved")
+    TestRunner.assertEqual(ref.originalFilename, "photo.jpg", "Original filename preserved")
+    TestRunner.assertEqual(ref.width, 1024, "Width preserved")
+    TestRunner.assertEqual(ref.height, 768, "Height preserved")
+    TestRunner.assertEqual(ref.format, "jpeg", "Format preserved")
+    TestRunner.assertEqual(ref.thumbnailBase64, thumbData.base64EncodedString(), "Thumbnail base64 correct")
+}
+
+func testSaveLoadRoundTrip() {
+    TestRunner.suite("Save/Load Round Trip (simulated)")
+
+    let id = UUID()
+    let imageData = Data(repeating: 0xFF, count: 500)
+    let thumbData = Data(repeating: 0xAA, count: 50)
+    let attachment = ImageAttachment(
+        id: id, imageData: imageData, thumbnailData: thumbData,
+        originalFilename: "test.png", width: 640, height: 480, fileSize: 500,
+        format: .png, mimeType: "image/png", sourceType: .filePicker
+    )
+
+    // Simulate save: write image data to temp file
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("extremis-test-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    let ref = ImageRef(from: attachment)
+    let filePath = tempDir.appendingPathComponent(ref.filename)
+
+    do {
+        try imageData.write(to: filePath, options: .atomic)
+        TestRunner.assertTrue(FileManager.default.fileExists(atPath: filePath.path), "Image file written to disk")
+
+        // Simulate load: read back
+        let loadedData = try Data(contentsOf: filePath)
+        TestRunner.assertEqual(loadedData, imageData, "Loaded data matches original")
+        TestRunner.assertEqual(loadedData.count, 500, "Loaded data size correct")
+    } catch {
+        TestRunner.assertTrue(false, "Save/load round trip failed: \(error)")
+    }
+
+    // Cleanup
+    try? FileManager.default.removeItem(at: tempDir)
+}
+
+func testDeleteImageFile() {
+    TestRunner.suite("Delete Image File")
+
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("extremis-test-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+    let filename = "\(UUID().uuidString).jpeg"
+    let filePath = tempDir.appendingPathComponent(filename)
+
+    // Write
+    try? Data(repeating: 0xFF, count: 100).write(to: filePath)
+    TestRunner.assertTrue(FileManager.default.fileExists(atPath: filePath.path), "File exists before delete")
+
+    // Delete
+    try? FileManager.default.removeItem(at: filePath)
+    TestRunner.assertFalse(FileManager.default.fileExists(atPath: filePath.path), "File removed after delete")
+
+    // Cleanup
+    try? FileManager.default.removeItem(at: tempDir)
+}
+
+func testMissingFileHandling() {
+    TestRunner.suite("Missing File Handling")
+
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("extremis-test-\(UUID().uuidString)")
+    let nonExistentFile = tempDir.appendingPathComponent("nonexistent.jpeg")
+
+    let exists = FileManager.default.fileExists(atPath: nonExistentFile.path)
+    TestRunner.assertFalse(exists, "Non-existent file correctly detected")
+
+    // Attempting to load should fail gracefully
+    do {
+        _ = try Data(contentsOf: nonExistentFile)
+        TestRunner.assertTrue(false, "Should have thrown for missing file")
+    } catch {
+        TestRunner.assertTrue(true, "Missing file throws error as expected")
+    }
+}
+
+func testThumbnailBase64InRef() {
+    TestRunner.suite("Thumbnail Base64 in ImageRef")
+
+    let thumbData = Data([0x01, 0x02, 0x03, 0x04, 0x05])
+    let attachment = ImageAttachment(
+        id: UUID(), imageData: Data(repeating: 0xFF, count: 100), thumbnailData: thumbData,
+        width: 200, height: 150, fileSize: 100,
+        format: .jpeg, mimeType: "image/jpeg", sourceType: .clipboard
+    )
+    let ref = ImageRef(from: attachment)
+
+    // Verify base64 can be decoded back
+    if let decoded = Data(base64Encoded: ref.thumbnailBase64) {
+        TestRunner.assertEqual(decoded, thumbData, "Thumbnail base64 decodes to original data")
+    } else {
+        TestRunner.assertTrue(false, "Thumbnail base64 decoding failed")
+    }
+}
+
+func testMultipleImagesSaveLoad() {
+    TestRunner.suite("Multiple Images Save/Load")
+
+    let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent("extremis-test-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+    var refs: [ImageRef] = []
+    let imageCount = 5
+
+    // Save multiple images
+    for i in 0..<imageCount {
+        let attachment = ImageAttachment(
+            imageData: Data(repeating: UInt8(i), count: 100 + i * 10),
+            thumbnailData: Data(repeating: UInt8(i), count: 20),
+            width: 100, height: 100, fileSize: 100 + i * 10,
+            format: i % 2 == 0 ? .jpeg : .png,
+            mimeType: i % 2 == 0 ? "image/jpeg" : "image/png",
+            sourceType: .clipboard
+        )
+        let ref = ImageRef(from: attachment)
+        let filePath = tempDir.appendingPathComponent(ref.filename)
+        try? attachment.imageData.write(to: filePath)
+        refs.append(ref)
+    }
+
+    TestRunner.assertEqual(refs.count, imageCount, "Created \(imageCount) image refs")
+
+    // Load all back
+    var loadedCount = 0
+    for ref in refs {
+        let filePath = tempDir.appendingPathComponent(ref.filename)
+        if FileManager.default.fileExists(atPath: filePath.path) {
+            loadedCount += 1
+        }
+    }
+    TestRunner.assertEqual(loadedCount, imageCount, "All \(imageCount) image files loadable")
+
+    // Cleanup
+    try? FileManager.default.removeItem(at: tempDir)
+}
+
+// MARK: - Entry Point
+
+@main
+struct ImagePersistenceTests {
+    static func main() {
+        print("🧪 ImagePersistence Tests")
+        print("==================================================")
+
+        testFileNamingConvention()
+        testImageRefPreservesMetadata()
+        testSaveLoadRoundTrip()
+        testDeleteImageFile()
+        testMissingFileHandling()
+        testThumbnailBase64InRef()
+        testMultipleImagesSaveLoad()
+
+        TestRunner.printSummary()
+        if TestRunner.failedCount > 0 { exit(1) }
+    }
+}

--- a/Extremis/UI/PromptWindow/ChatInputView.swift
+++ b/Extremis/UI/PromptWindow/ChatInputView.swift
@@ -1,37 +1,51 @@
 // MARK: - Chat Input View
-// Text input field for sending chat messages
+// Text input field for sending chat messages with image attachment support
 
 import SwiftUI
 import AppKit
+import UniformTypeIdentifiers
 
 /// View for entering and sending chat messages
 struct ChatInputView: View {
     @Binding var text: String
+    @Binding var pendingAttachments: [ImageAttachment]
     let isEnabled: Bool
     let isGenerating: Bool
     let placeholder: String
     let autoFocus: Bool
+    let supportsVision: Bool
     let onSend: () -> Void
     var onStopGeneration: (() -> Void)?
+    /// Called when user attempts to paste an image but the model doesn't support vision
+    var onNonVisionPasteAttempt: (() -> Void)?
 
     @State private var isFocused: Bool = false
+    @State private var imageError: String?
+    @State private var imageErrorDismissId: UUID = UUID()
+    @State private var isDropTargeted: Bool = false
 
     init(
         text: Binding<String>,
+        pendingAttachments: Binding<[ImageAttachment]> = .constant([]),
         isEnabled: Bool = true,
         isGenerating: Bool = false,
         placeholder: String = "Type a follow-up message...",
         autoFocus: Bool = false,
+        supportsVision: Bool = false,
         onSend: @escaping () -> Void,
-        onStopGeneration: (() -> Void)? = nil
+        onStopGeneration: (() -> Void)? = nil,
+        onNonVisionPasteAttempt: (() -> Void)? = nil
     ) {
         self._text = text
+        self._pendingAttachments = pendingAttachments
         self.isEnabled = isEnabled
         self.isGenerating = isGenerating
         self.placeholder = placeholder
         self.autoFocus = autoFocus
+        self.supportsVision = supportsVision
         self.onSend = onSend
         self.onStopGeneration = onStopGeneration
+        self.onNonVisionPasteAttempt = onNonVisionPasteAttempt
     }
 
     // Track the actual content height from NSTextView
@@ -45,41 +59,89 @@ struct ChatInputView: View {
     }
 
     var body: some View {
-        HStack(alignment: .bottom, spacing: 8) {
-            // Scrollable text input using NSTextView for performance
-            ScrollableChatTextEditor(
-                text: $text,
-                placeholder: placeholder,
-                isEnabled: isEnabled,
-                autoFocus: autoFocus,
-                isFocused: $isFocused,
-                contentHeight: $contentHeight,
-                onSend: { sendIfNotEmpty() }
-            )
-            .frame(height: textHeight)
-
-            // Show stop button when generating, otherwise show send button
-            if isGenerating {
-                Button(action: { onStopGeneration?() }) {
-                    Image(systemName: "stop.circle.fill")
-                        .font(.title2)
-                        .foregroundColor(.red)
-                }
-                .buttonStyle(.plain)
-                .help("Stop generating")
-            } else {
-                Button(action: sendIfNotEmpty) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.title2)
-                        .foregroundColor(canSend ? .accentColor : .secondary)
-                }
-                .buttonStyle(.plain)
-                .disabled(!canSend)
-                .help("Send message (Enter)")
+        VStack(spacing: 0) {
+            // Thumbnail strip for pending attachments
+            if !pendingAttachments.isEmpty {
+                ImageAttachmentView(
+                    attachments: pendingAttachments,
+                    onRemove: { id in
+                        pendingAttachments.removeAll { $0.id == id }
+                    }
+                )
+                .padding(.horizontal, 12)
+                .padding(.top, 6)
             }
+
+            // Brief image error message
+            if let errorMsg = imageError {
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.system(size: 10))
+                    Text(errorMsg)
+                        .font(.system(size: 11))
+                }
+                .foregroundColor(.orange)
+                .padding(.horizontal, 12)
+                .padding(.top, 4)
+                .transition(.opacity)
+            }
+
+            HStack(alignment: .bottom, spacing: 8) {
+                // Attachment button (only when vision is supported)
+                if supportsVision {
+                    Button(action: openFilePicker) {
+                        Image(systemName: "paperclip")
+                            .font(.system(size: 16))
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(pendingAttachments.count >= ImageProcessor.shared.maxImagesPerMessage)
+                    .help(pendingAttachments.count >= ImageProcessor.shared.maxImagesPerMessage
+                          ? "Maximum \(ImageProcessor.shared.maxImagesPerMessage) images"
+                          : "Attach image")
+                }
+
+                // Scrollable text input using NSTextView for performance
+                ScrollableChatTextEditor(
+                    text: $text,
+                    placeholder: placeholder,
+                    isEnabled: isEnabled,
+                    autoFocus: autoFocus,
+                    isFocused: $isFocused,
+                    contentHeight: $contentHeight,
+                    onSend: { sendIfReady() },
+                    onPasteImage: supportsVision ? { imageData in
+                        processAndAttachImage(data: imageData, sourceType: .clipboard)
+                    } : nil,
+                    onPasteImageBlocked: !supportsVision ? {
+                        onNonVisionPasteAttempt?()
+                    } : nil
+                )
+                .frame(height: textHeight)
+
+                // Show stop button when generating, otherwise show send button
+                if isGenerating {
+                    Button(action: { onStopGeneration?() }) {
+                        Image(systemName: "stop.circle.fill")
+                            .font(.title2)
+                            .foregroundColor(.red)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Stop generating")
+                } else {
+                    Button(action: sendIfReady) {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.title2)
+                            .foregroundColor(canSend ? .accentColor : .secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!canSend)
+                    .help("Send message (Enter)")
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 4)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 4)
         .background(.thinMaterial)
         .continuousCornerRadius(DS.Radii.pill)
         .overlay(
@@ -88,18 +150,118 @@ struct ChatInputView: View {
                 .animation(DS.Animation.hoverTransition, value: isFocused)
         )
         .dsShadow(DS.Shadows.medium)
+        .overlay {
+            if supportsVision && isDropTargeted {
+                ImageDropZoneView()
+                    .transition(.opacity)
+                    .animation(.easeInOut(duration: 0.15), value: isDropTargeted)
+            }
+        }
+        .onDrop(of: [.image], isTargeted: supportsVision ? $isDropTargeted : .constant(false)) { providers in
+            guard supportsVision else { return false }
+            handleDroppedItems(providers)
+            return true
+        }
     }
 
-    private func sendIfNotEmpty() {
-        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+    // MARK: - Drag and Drop
+
+    private func handleDroppedItems(_ providers: [NSItemProvider]) {
+        let remaining = ImageProcessor.shared.maxImagesPerMessage - pendingAttachments.count
+        guard remaining > 0 else {
+            showImageError("Maximum \(ImageProcessor.shared.maxImagesPerMessage) images per message")
+            return
+        }
+
+        for provider in providers.prefix(remaining) {
+            provider.loadDataRepresentation(forTypeIdentifier: UTType.image.identifier) { data, error in
+                guard let data = data else { return }
+                DispatchQueue.main.async {
+                    self.processAndAttachImage(data: data, sourceType: .dragAndDrop)
+                }
+            }
+        }
+    }
+
+    // MARK: - File Picker
+
+    private func openFilePicker() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = ImageProcessor.supportedUTTypes
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        panel.canChooseFiles = true
+        panel.message = "Select images to attach"
+
+        let remaining = ImageProcessor.shared.maxImagesPerMessage - pendingAttachments.count
+        guard remaining > 0 else {
+            showImageError("Maximum \(ImageProcessor.shared.maxImagesPerMessage) images per message")
+            return
+        }
+
+        guard panel.runModal() == .OK else { return }
+
+        for url in panel.urls.prefix(remaining) {
+            guard let data = try? Data(contentsOf: url) else { continue }
+            processAndAttachImage(data: data, sourceType: .filePicker, filename: url.lastPathComponent)
+        }
+    }
+
+    // MARK: - Image Processing
+
+    private func processAndAttachImage(data: Data, sourceType: ImageSourceType, filename: String? = nil) {
+        // Check max images limit
+        guard pendingAttachments.count < ImageProcessor.shared.maxImagesPerMessage else {
+            showImageError("Maximum \(ImageProcessor.shared.maxImagesPerMessage) images per message")
+            return
+        }
+
+        do {
+            let attachment = try ImageProcessor.shared.process(data: data, sourceType: sourceType, originalFilename: filename)
+            pendingAttachments.append(attachment)
+            imageError = nil
+        } catch let error as ImageProcessingError {
+            switch error {
+            case .unsupportedFormat:
+                showImageError("Unsupported image format")
+            case .inputTooLarge(let size):
+                let mbSize = Double(size) / 1_048_576.0
+                showImageError("Image too large (\(String(format: "%.1f", mbSize))MB, max 10MB)")
+            case .processingFailed:
+                showImageError("Failed to process image")
+            case .outputTooLarge:
+                showImageError("Processed image too large")
+            }
+        } catch {
+            showImageError("Failed to attach image")
+        }
+    }
+
+    private func showImageError(_ message: String) {
+        imageError = message
+        let dismissId = UUID()
+        imageErrorDismissId = dismissId
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            if imageErrorDismissId == dismissId {
+                imageError = nil
+            }
+        }
+    }
+
+    // MARK: - Send Logic
+
+    private func sendIfReady() {
+        guard canSend else { return }
         onSend()
         text = ""
-        // Reset content height to minimum when text is cleared
         contentHeight = minHeight
     }
 
     private var canSend: Bool {
-        isEnabled && !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        guard isEnabled else { return false }
+        let hasText = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hasImages = !pendingAttachments.isEmpty
+        return hasText || hasImages
     }
 }
 
@@ -115,16 +277,134 @@ struct ScrollableChatTextEditor: NSViewRepresentable {
     @Binding var isFocused: Bool
     @Binding var contentHeight: CGFloat
     let onSend: () -> Void
+    /// Called when an image is pasted from clipboard (only set when vision is supported)
+    var onPasteImage: ((Data) -> Void)?
+    /// Called when an image paste is attempted but vision is not supported
+    var onPasteImageBlocked: (() -> Void)?
+
+    /// Custom NSTextView subclass that intercepts paste to detect images
+    class ImageAwareTextView: NSTextView {
+        var onPasteImage: ((Data) -> Void)?
+        var onPasteImageBlocked: (() -> Void)?
+
+        /// Pasteboard types that indicate image content
+        private static let imageTypes: [NSPasteboard.PasteboardType] = [
+            .tiff, .png,
+            NSPasteboard.PasteboardType("public.jpeg"),
+            NSPasteboard.PasteboardType("public.heic"),
+        ]
+
+        /// Intercept Cmd+V at the key equivalent level since paste: doesn't fire
+        /// in nonactivating panel windows (no standard Edit menu)
+        override func performKeyEquivalent(with event: NSEvent) -> Bool {
+            if event.modifierFlags.contains(.command),
+               event.charactersIgnoringModifiers == "v" {
+                if handleImagePaste() {
+                    return true  // Consumed — image was handled
+                }
+            }
+            return super.performKeyEquivalent(with: event)
+        }
+
+        /// Also override paste: for cases where it IS called (e.g., Edit menu, right-click > Paste)
+        override func paste(_ sender: Any?) {
+            if handleImagePaste() {
+                return  // Consumed
+            }
+            super.paste(sender)
+        }
+
+        /// Shared image paste logic — returns true if an image was detected and handled
+        private func handleImagePaste() -> Bool {
+            let pasteboard = NSPasteboard.general
+
+            guard Self.pasteboardHasImage(pasteboard) else { return false }
+
+            if let onPasteImage {
+                // Vision supported — extract and handle image
+                if let imageData = Self.extractImageData(from: pasteboard) {
+                    onPasteImage(imageData)
+                }
+                // Also paste any text alongside the image
+                if let textContent = pasteboard.string(forType: .string), !textContent.isEmpty {
+                    insertText(textContent, replacementRange: selectedRange())
+                }
+                return true
+            } else if let onPasteImageBlocked {
+                // Vision not supported — notify user
+                onPasteImageBlocked()
+                // Still allow text paste if available
+                if pasteboard.string(forType: .string) != nil {
+                    // Can't call super.paste from here, so insert text directly
+                    if let text = pasteboard.string(forType: .string) {
+                        insertText(text, replacementRange: selectedRange())
+                    }
+                }
+                return true
+            }
+
+            return false  // No image handler set, let default handle it
+        }
+
+        static func pasteboardHasImage(_ pasteboard: NSPasteboard) -> Bool {
+            for type in imageTypes {
+                if pasteboard.data(forType: type) != nil {
+                    return true
+                }
+            }
+            if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: [
+                .urlReadingContentsConformToTypes: [UTType.image.identifier]
+            ]) as? [URL], !urls.isEmpty {
+                return true
+            }
+            return false
+        }
+
+        static func extractImageData(from pasteboard: NSPasteboard) -> Data? {
+            // Primary: use NSImage which handles all macOS pasteboard formats natively
+            // then convert to PNG for reliable downstream processing
+            if let image = NSImage(pasteboard: pasteboard),
+               let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+                let rep = NSBitmapImageRep(cgImage: cgImage)
+                if let pngData = rep.representation(using: .png, properties: [:]) {
+                    return pngData
+                }
+            }
+            // Fallback: try raw pasteboard data for specific types
+            for type in imageTypes {
+                if let data = pasteboard.data(forType: type) {
+                    return data
+                }
+            }
+            // Fallback: try image file URLs on pasteboard
+            if let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: [
+                .urlReadingContentsConformToTypes: [UTType.image.identifier]
+            ]) as? [URL], let url = urls.first {
+                return try? Data(contentsOf: url)
+            }
+            return nil
+        }
+    }
 
     func makeNSView(context: NSViewRepresentableContext<ScrollableChatTextEditor>) -> NSScrollView {
-        let scrollView = NSTextView.scrollableTextView()
-        let textView = scrollView.documentView as! NSTextView
+        // Use the standard factory to get a properly wired scroll view + text view
+        let scrollView = ImageAwareTextView.scrollableTextView()
+        let standardTextView = scrollView.documentView as! NSTextView
+
+        // Replace the standard NSTextView with our ImageAwareTextView subclass,
+        // reusing the existing (properly wired) text container from the factory
+        let textView = ImageAwareTextView(frame: standardTextView.frame, textContainer: standardTextView.textContainer)
+        textView.minSize = standardTextView.minSize
+        textView.maxSize = standardTextView.maxSize
+        textView.isVerticallyResizable = standardTextView.isVerticallyResizable
+        textView.isHorizontallyResizable = standardTextView.isHorizontallyResizable
+        textView.autoresizingMask = standardTextView.autoresizingMask
 
         textView.delegate = context.coordinator
         textView.font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
         textView.isRichText = false
         textView.allowsUndo = true
-        textView.isEditable = true  // Always editable so user can type while generating
+        textView.isEditable = true
         textView.isSelectable = true
         textView.backgroundColor = .clear
         textView.drawsBackground = false
@@ -132,9 +412,12 @@ struct ScrollableChatTextEditor: NSViewRepresentable {
         textView.isAutomaticQuoteSubstitutionEnabled = false
         textView.isAutomaticDashSubstitutionEnabled = false
 
-        scrollView.hasVerticalScroller = true
-        scrollView.hasHorizontalScroller = false
-        scrollView.autohidesScrollers = true
+        // Set image paste handlers
+        textView.onPasteImage = onPasteImage
+        textView.onPasteImageBlocked = onPasteImageBlocked
+
+        // Replace document view with our subclass
+        scrollView.documentView = textView
         scrollView.borderType = .noBorder
         scrollView.drawsBackground = false
 
@@ -152,7 +435,7 @@ struct ScrollableChatTextEditor: NSViewRepresentable {
     }
 
     func updateNSView(_ scrollView: NSScrollView, context: NSViewRepresentableContext<ScrollableChatTextEditor>) {
-        guard let textView = scrollView.documentView as? NSTextView else { return }
+        guard let textView = scrollView.documentView as? ImageAwareTextView else { return }
 
         // Update text only if different to avoid cursor jump
         if textView.string != text {
@@ -165,12 +448,22 @@ struct ScrollableChatTextEditor: NSViewRepresentable {
         // Update coordinator's isEnabled state for Enter key handling
         context.coordinator.isEnabled = isEnabled
 
+        // Update image paste handlers
+        textView.onPasteImage = onPasteImage
+        textView.onPasteImageBlocked = onPasteImageBlocked
+
         // Update placeholder visibility
         context.coordinator.updatePlaceholderVisibility(isEmpty: text.isEmpty)
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text, isFocused: $isFocused, contentHeight: $contentHeight, isEnabled: isEnabled, onSend: onSend)
+        Coordinator(
+            text: $text,
+            isFocused: $isFocused,
+            contentHeight: $contentHeight,
+            isEnabled: isEnabled,
+            onSend: onSend
+        )
     }
 
     // Custom NSTextField that passes through mouse clicks to the text view behind it
@@ -190,7 +483,13 @@ struct ScrollableChatTextEditor: NSViewRepresentable {
         let onSend: () -> Void
         private var placeholderLabel: NSTextField?
 
-        init(text: Binding<String>, isFocused: Binding<Bool>, contentHeight: Binding<CGFloat>, isEnabled: Bool, onSend: @escaping () -> Void) {
+        init(
+            text: Binding<String>,
+            isFocused: Binding<Bool>,
+            contentHeight: Binding<CGFloat>,
+            isEnabled: Bool,
+            onSend: @escaping () -> Void
+        ) {
             _text = text
             _isFocused = isFocused
             _contentHeight = contentHeight

--- a/Extremis/UI/PromptWindow/ChatMessageView.swift
+++ b/Extremis/UI/PromptWindow/ChatMessageView.swift
@@ -15,6 +15,7 @@ struct ChatMessageView: View {
     var context: Context? = nil
 
     @State private var isHovering = false
+    @State private var hoverGeneration = 0
     @State private var showCopied = false
     @State private var showContextSheet = false
     /// Collapse tool history by default after generation completes
@@ -107,18 +108,28 @@ struct ChatMessageView: View {
                         .padding(.horizontal, 4)
                         .padding(.vertical, 4)
                 } else {
-                    // User: prominent colored bubble
-                    Text(message.content)
-                        .font(.body)
-                        .textSelection(.enabled)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
-                        .background(DS.Colors.userBubble)
-                        .continuousCornerRadius(DS.Radii.large)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: DS.Radii.large, style: .continuous)
-                                .stroke(DS.Colors.userBubbleBorder, lineWidth: 1)
-                        )
+                    // User: prominent colored bubble with optional images
+                    VStack(alignment: .trailing, spacing: 6) {
+                        // Image thumbnails (if any)
+                        if message.hasImages, let images = message.imageAttachments {
+                            ChatMessageImageView(attachments: images)
+                        }
+
+                        // Text content (may be empty for image-only messages)
+                        if !message.content.isEmpty {
+                            Text(message.content)
+                                .font(.body)
+                                .textSelection(.enabled)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(DS.Colors.userBubble)
+                    .continuousCornerRadius(DS.Radii.large)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DS.Radii.large, style: .continuous)
+                            .stroke(DS.Colors.userBubbleBorder, lineWidth: 1)
+                    )
                 }
 
                 // Action buttons at bottom (always in layout, visibility controlled by opacity)
@@ -158,9 +169,21 @@ struct ChatMessageView: View {
 
             if !isUser { Spacer(minLength: 40) }
         }
+        .contentShape(Rectangle())
         .onHover { hovering in
-            withAnimation(DS.Animation.hoverTransition) {
-                isHovering = hovering
+            if hovering {
+                hoverGeneration += 1
+                withAnimation(DS.Animation.hoverTransition) {
+                    isHovering = true
+                }
+            } else {
+                let gen = hoverGeneration
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                    guard gen == hoverGeneration else { return }
+                    withAnimation(DS.Animation.hoverTransition) {
+                        isHovering = false
+                    }
+                }
             }
         }
         .sheet(isPresented: $showContextSheet) {
@@ -321,6 +344,7 @@ struct StreamingMessageView: View {
     let isGenerating: Bool
 
     @State private var isHovering = false
+    @State private var hoverGeneration = 0
     @State private var showCopied = false
 
     private var canCopy: Bool {
@@ -384,9 +408,21 @@ struct StreamingMessageView: View {
 
             Spacer(minLength: 40)
         }
+        .contentShape(Rectangle())
         .onHover { hovering in
-            withAnimation(DS.Animation.hoverTransition) {
-                isHovering = hovering
+            if hovering {
+                hoverGeneration += 1
+                withAnimation(DS.Animation.hoverTransition) {
+                    isHovering = true
+                }
+            } else {
+                let gen = hoverGeneration
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                    guard gen == hoverGeneration else { return }
+                    withAnimation(DS.Animation.hoverTransition) {
+                        isHovering = false
+                    }
+                }
             }
         }
     }

--- a/Extremis/UI/PromptWindow/ImageAttachmentView.swift
+++ b/Extremis/UI/PromptWindow/ImageAttachmentView.swift
@@ -1,0 +1,306 @@
+// MARK: - Image Attachment View
+// Horizontal thumbnail strip for pending and displayed image attachments
+
+import SwiftUI
+
+/// Horizontal scrollable strip of image thumbnails with remove buttons
+struct ImageAttachmentView: View {
+    let attachments: [ImageAttachment]
+    let onRemove: ((UUID) -> Void)?
+
+    init(attachments: [ImageAttachment], onRemove: ((UUID) -> Void)? = nil) {
+        self.attachments = attachments
+        self.onRemove = onRemove
+    }
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: DS.Spacing.sm) {
+                ForEach(attachments) { attachment in
+                    ImageThumbnailView(
+                        attachment: attachment,
+                        onRemove: onRemove != nil ? { onRemove?(attachment.id) } : nil
+                    )
+                }
+            }
+            .padding(.horizontal, DS.Spacing.xs)
+            .padding(.vertical, DS.Spacing.xs)
+        }
+    }
+}
+
+/// Single image thumbnail with optional remove button
+struct ImageThumbnailView: View {
+    let attachment: ImageAttachment
+    var onRemove: (() -> Void)?
+
+    @State private var isHovering = false
+
+    private let thumbnailSize: CGFloat = 80
+
+    var body: some View {
+        VStack(spacing: 2) {
+            ZStack(alignment: .topTrailing) {
+                thumbnailImage
+                    .frame(width: thumbnailSize, height: thumbnailSize)
+                    .continuousCornerRadius(DS.Radii.medium)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DS.Radii.medium, style: .continuous)
+                            .stroke(DS.Colors.borderSubtle, lineWidth: 1)
+                    )
+
+                if let onRemove, isHovering {
+                    Button(action: onRemove) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 16))
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(.white, Color.secondary.opacity(0.8))
+                    }
+                    .buttonStyle(.plain)
+                    .offset(x: 4, y: -4)
+                    .transition(.opacity)
+                }
+            }
+            .onHover { hovering in
+                withAnimation(DS.Animation.hoverTransition) {
+                    isHovering = hovering
+                }
+            }
+
+            Text(attachment.displayLabel)
+                .font(.system(size: 9))
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .frame(width: thumbnailSize)
+        }
+    }
+
+    @ViewBuilder
+    private var thumbnailImage: some View {
+        if let nsImage = NSImage(data: attachment.thumbnailData) {
+            Image(nsImage: nsImage)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: thumbnailSize, height: thumbnailSize)
+                .clipped()
+        } else {
+            // Fallback placeholder
+            Rectangle()
+                .fill(DS.Colors.surfaceElevated)
+                .overlay {
+                    Image(systemName: "photo")
+                        .foregroundColor(.secondary)
+                }
+        }
+    }
+}
+
+// MARK: - Chat History Image View
+
+/// Renders image thumbnails inline within chat message bubbles (read-only, no remove)
+/// Single image: full-width. 2+ images: 2-column grid layout.
+/// Click on any image to expand it to full size.
+struct ChatMessageImageView: View {
+    let attachments: [ImageAttachment]
+
+    @State private var expandedAttachment: ImageAttachment?
+
+    private let maxSingleImageWidth: CGFloat = 300
+    private let gridSpacing: CGFloat = 4
+    private let gridThumbnailSize: CGFloat = 120
+
+    var body: some View {
+        Group {
+            if attachments.count == 1, let attachment = attachments.first {
+                singleImageView(attachment)
+            } else {
+                gridImageView
+            }
+        }
+        .sheet(item: $expandedAttachment) { attachment in
+            ExpandedImageView(attachment: attachment)
+        }
+    }
+
+    @ViewBuilder
+    private func singleImageView(_ attachment: ImageAttachment) -> some View {
+        if let nsImage = NSImage(data: attachment.thumbnailData) {
+            let aspectRatio = CGFloat(attachment.width) / max(CGFloat(attachment.height), 1)
+            let displayWidth = min(maxSingleImageWidth, CGFloat(attachment.width))
+            let displayHeight = displayWidth / aspectRatio
+
+            Image(nsImage: nsImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(maxWidth: displayWidth, maxHeight: displayHeight)
+                .continuousCornerRadius(DS.Radii.medium)
+                .overlay(
+                    RoundedRectangle(cornerRadius: DS.Radii.medium, style: .continuous)
+                        .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+                )
+                .onTapGesture { expandedAttachment = attachment }
+                .cursor(.pointingHand)
+        } else {
+            imagePlaceholder
+        }
+    }
+
+    private var gridImageView: some View {
+        let columns = [
+            GridItem(.fixed(gridThumbnailSize), spacing: gridSpacing),
+            GridItem(.fixed(gridThumbnailSize), spacing: gridSpacing)
+        ]
+        return LazyVGrid(columns: columns, spacing: gridSpacing) {
+            ForEach(attachments) { attachment in
+                if let nsImage = NSImage(data: attachment.thumbnailData) {
+                    Image(nsImage: nsImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: gridThumbnailSize, height: gridThumbnailSize)
+                        .clipped()
+                        .continuousCornerRadius(DS.Radii.small)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: DS.Radii.small, style: .continuous)
+                                .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+                        )
+                        .onTapGesture { expandedAttachment = attachment }
+                        .cursor(.pointingHand)
+                } else {
+                    imagePlaceholder
+                        .frame(width: gridThumbnailSize, height: gridThumbnailSize)
+                }
+            }
+        }
+    }
+
+    private var imagePlaceholder: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "photo")
+                .foregroundColor(.secondary)
+            Text("Image unavailable")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(DS.Spacing.sm)
+        .background(DS.Colors.surfaceElevated)
+        .continuousCornerRadius(DS.Radii.medium)
+    }
+}
+
+// MARK: - Expanded Image View
+
+/// Full-size image viewer shown as a sheet when clicking a chat image.
+/// Adapts to image aspect ratio and screen size (Quick Look style).
+struct ExpandedImageView: View {
+    let attachment: ImageAttachment
+    @Environment(\.dismiss) private var dismiss
+
+    /// Compute display size: fit image within 75% of screen, preserving aspect ratio
+    private var displaySize: CGSize {
+        let screen = NSScreen.main?.visibleFrame.size ?? CGSize(width: 1200, height: 800)
+        let maxWidth = screen.width * 0.75
+        let maxHeight = screen.height * 0.75
+        let headerHeight: CGFloat = 50
+
+        let imgW = CGFloat(attachment.width)
+        let imgH = CGFloat(attachment.height)
+        let aspectRatio = imgW / max(imgH, 1)
+
+        // Start with image's natural size
+        var width = imgW
+        var height = imgH
+
+        // Scale down to fit screen constraints
+        if width > maxWidth {
+            width = maxWidth
+            height = width / aspectRatio
+        }
+        if height > (maxHeight - headerHeight) {
+            height = maxHeight - headerHeight
+            width = height * aspectRatio
+        }
+
+        // Enforce minimum
+        width = max(width, 320)
+        height = max(height, 200)
+
+        return CGSize(width: width, height: height + headerHeight)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header bar
+            HStack {
+                Text(attachment.originalFilename ?? "Image")
+                    .font(.headline)
+                    .lineLimit(1)
+                Spacer()
+                Text("\(attachment.width) × \(attachment.height)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Button(action: { dismiss() }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title2)
+                        .symbolRenderingMode(.hierarchical)
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .keyboardShortcut(.escape, modifiers: [])
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            // Image area with dark background
+            ZStack {
+                Color.black.opacity(0.85)
+
+                if let nsImage = NSImage(data: attachment.imageData) {
+                    Image(nsImage: nsImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .padding(8)
+                } else {
+                    VStack(spacing: 8) {
+                        Image(systemName: "photo.trianglebadge.exclamationmark")
+                            .font(.largeTitle)
+                        Text("Unable to load image")
+                            .font(.callout)
+                    }
+                    .foregroundColor(.secondary)
+                }
+            }
+        }
+        .frame(width: displaySize.width, height: displaySize.height)
+    }
+}
+
+// MARK: - Cursor Helper
+
+private extension View {
+    func cursor(_ cursor: NSCursor) -> some View {
+        onHover { inside in
+            if inside { cursor.push() } else { NSCursor.pop() }
+        }
+    }
+}
+
+// MARK: - ImageAttachment Display Label Extension
+
+extension ImageAttachment {
+    /// Display label for the thumbnail — filename or generic label based on source
+    var displayLabel: String {
+        if let name = originalFilename, !name.isEmpty {
+            return name
+        }
+        switch sourceType {
+        case .clipboard:
+            return "Pasted image"
+        case .filePicker:
+            return "Selected image"
+        case .dragAndDrop:
+            return "Dropped image"
+        }
+    }
+}

--- a/Extremis/UI/PromptWindow/ImageDropZoneView.swift
+++ b/Extremis/UI/PromptWindow/ImageDropZoneView.swift
@@ -1,0 +1,34 @@
+// MARK: - Image Drop Zone View
+// Overlay shown when user drags images over the chat input area
+
+import SwiftUI
+
+/// Semi-transparent overlay indicating a valid drop zone for images
+struct ImageDropZoneView: View {
+    var body: some View {
+        ZStack {
+            // Background overlay
+            DS.Colors.surfacePrimary
+                .opacity(0.85)
+
+            // Drop indicator
+            VStack(spacing: DS.Spacing.sm) {
+                Image(systemName: "photo.on.rectangle.angled")
+                    .font(.system(size: 28))
+                    .foregroundColor(.accentColor)
+
+                Text("Drop images here")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.primary)
+            }
+            .padding(DS.Spacing.lg)
+            .background(.ultraThinMaterial)
+            .continuousCornerRadius(DS.Radii.large)
+            .overlay(
+                RoundedRectangle(cornerRadius: DS.Radii.large, style: .continuous)
+                    .strokeBorder(DS.Colors.borderFocused, style: StrokeStyle(lineWidth: 2, dash: [8, 4]))
+            )
+        }
+        .continuousCornerRadius(DS.Radii.pill)
+    }
+}

--- a/Extremis/UI/PromptWindow/PromptWindowController.swift
+++ b/Extremis/UI/PromptWindow/PromptWindowController.swift
@@ -404,12 +404,21 @@ final class PromptViewModel: ObservableObject {
     /// Callback when user approves all tools (one-time, no remember)
     var onApproveAll: (() -> Void)?
 
+    // Image attachment state
+    @Published var pendingImageAttachments: [ImageAttachment] = []
+    @Published var showNonVisionToast: Bool = false
+
     // Command palette state
     @Published var showCommandPalette: Bool = false
     @Published var commandFilter: String = ""
 
     /// Command manager for accessing commands
     let commandManager = CommandManager.shared
+
+    /// Whether the active model supports vision/image inputs
+    var supportsVision: Bool {
+        LLMProviderRegistry.shared.activeProvider?.supportsVision ?? false
+    }
 
     // Persistence properties
     private(set) var sessionId: UUID?
@@ -845,6 +854,14 @@ final class PromptViewModel: ObservableObject {
 
     // MARK: - Chat Mode
 
+    /// Show a brief toast when user tries to paste an image with a non-vision model
+    func showNonVisionPasteNotification() {
+        showNonVisionToast = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
+            self?.showNonVisionToast = false
+        }
+    }
+
     /// Enable chat mode after initial response is complete
     /// Note: This is now called when user submits a follow-up message
     /// The session may already exist from initial generation, so we only need to enable chat mode
@@ -888,7 +905,8 @@ final class PromptViewModel: ObservableObject {
     /// Send a chat message and get a response
     func sendChatMessage() {
         let messageText = chatInputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !messageText.isEmpty else { return }
+        let images = pendingImageAttachments.isEmpty ? nil : pendingImageAttachments
+        guard !messageText.isEmpty || images != nil else { return }
 
         // If no session exists, create one for the chat
         if session == nil {
@@ -909,13 +927,14 @@ final class PromptViewModel: ObservableObject {
         // Follow-up messages within the same spawn don't need context
         let message: ChatMessage
         if isFirstMessageSinceSpawn, let ctx = currentContext {
-            message = ChatMessage.user(messageText, context: ctx, intent: .chat)
+            message = ChatMessage.user(messageText, context: ctx, intent: .chat, imageAttachments: images)
             isFirstMessageSinceSpawn = false  // Consume the flag
         } else {
-            message = ChatMessage.user(messageText)
+            message = ChatMessage(role: .user, content: messageText, intent: .followUp, imageAttachments: images)
         }
         sess.addMessage(message)
         chatInputText = ""
+        pendingImageAttachments = []
         error = nil
 
         // Capture session ID for generation tracking
@@ -1527,7 +1546,11 @@ struct PromptContainerView: View {
                         pendingApprovalRequests: viewModel.pendingApprovalRequests,
                         onApproveRequest: viewModel.onApproveRequest,
                         onDenyRequest: viewModel.onDenyRequest,
-                        onApproveAll: viewModel.onApproveAll
+                        onApproveAll: viewModel.onApproveAll,
+                        supportsVision: viewModel.supportsVision,
+                        showNonVisionToast: viewModel.showNonVisionToast,
+                        onNonVisionPasteAttempt: { viewModel.showNonVisionPasteNotification() },
+                        pendingImageAttachments: $viewModel.pendingImageAttachments
                     )
                     .id(sessionManager.currentSessionId)  // Force view recreation on session switch to reset scroll state
                 } else {

--- a/Extremis/UI/PromptWindow/ResponseView.swift
+++ b/Extremis/UI/PromptWindow/ResponseView.swift
@@ -38,6 +38,12 @@ struct ResponseView: View {
     var onDenyRequest: ((String) -> Void)?
     var onApproveAll: (() -> Void)?
 
+    // Image attachment state
+    var supportsVision: Bool = false
+    var showNonVisionToast: Bool = false
+    var onNonVisionPasteAttempt: (() -> Void)?
+    @Binding var pendingImageAttachments: [ImageAttachment]
+
     @State private var showCopiedToast = false
 
     // Auto-scroll tracking for quick mode
@@ -78,6 +84,10 @@ struct ResponseView: View {
         self.onApproveRequest = nil
         self.onDenyRequest = nil
         self.onApproveAll = nil
+        self.supportsVision = false
+        self.showNonVisionToast = false
+        self.onNonVisionPasteAttempt = nil
+        self._pendingImageAttachments = .constant([])
     }
 
     // Full initializer with chat support
@@ -105,7 +115,11 @@ struct ResponseView: View {
         pendingApprovalRequests: [ApprovalRequestDisplayModel] = [],
         onApproveRequest: ((String, Bool) -> Void)? = nil,
         onDenyRequest: ((String) -> Void)? = nil,
-        onApproveAll: (() -> Void)? = nil
+        onApproveAll: (() -> Void)? = nil,
+        supportsVision: Bool = false,
+        showNonVisionToast: Bool = false,
+        onNonVisionPasteAttempt: (() -> Void)? = nil,
+        pendingImageAttachments: Binding<[ImageAttachment]> = .constant([])
     ) {
         self.response = response
         self.isGenerating = isGenerating
@@ -131,6 +145,10 @@ struct ResponseView: View {
         self.onApproveRequest = onApproveRequest
         self.onDenyRequest = onDenyRequest
         self.onApproveAll = onApproveAll
+        self.supportsVision = supportsVision
+        self.showNonVisionToast = showNonVisionToast
+        self.onNonVisionPasteAttempt = onNonVisionPasteAttempt
+        self._pendingImageAttachments = pendingImageAttachments
     }
 
     var body: some View {
@@ -291,6 +309,14 @@ struct ResponseView: View {
                 }
             }
         }
+        .overlay(alignment: .bottom) {
+            if showNonVisionToast {
+                NonVisionToast()
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .padding(.bottom, 80)
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: showNonVisionToast)
     }
 
     @ViewBuilder
@@ -299,12 +325,15 @@ struct ResponseView: View {
             if isChatMode {
                 ChatInputView(
                     text: $chatInputText,
+                    pendingAttachments: $pendingImageAttachments,
                     isEnabled: !isGenerating,
                     isGenerating: isGenerating,
                     placeholder: "Ask a follow-up question...",
                     autoFocus: true,
+                    supportsVision: supportsVision,
                     onSend: { onSendChat?() },
-                    onStopGeneration: onStopGeneration
+                    onStopGeneration: onStopGeneration,
+                    onNonVisionPasteAttempt: onNonVisionPasteAttempt
                 )
             } else {
                 // Show "Continue chatting" prompt - entire row is clickable
@@ -393,6 +422,26 @@ struct ResponseView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 6)
+    }
+}
+
+// MARK: - Non-Vision Toast
+
+struct NonVisionToast: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "eye.slash")
+                .font(.system(size: 12, weight: .medium))
+            Text("Current model doesn't support images")
+                .font(.system(size: 12, weight: .medium))
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(.ultraThinMaterial)
+        .background(Color.secondary.opacity(0.7))
+        .continuousCornerRadius(DS.Radii.pill)
+        .dsShadow(DS.Shadows.medium)
     }
 }
 

--- a/Extremis/Utilities/ImagePersistence.swift
+++ b/Extremis/Utilities/ImagePersistence.swift
@@ -1,0 +1,148 @@
+// MARK: - Image Persistence
+// File-based image storage for chat session images
+
+import Foundation
+
+/// Manages saving and loading images to/from disk
+/// Images stored in ~/Library/Application Support/Extremis/images/
+actor ImagePersistence {
+    static let shared = ImagePersistence()
+
+    // MARK: - Paths
+
+    private var imagesDirectory: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            .appendingPathComponent("Extremis", isDirectory: true)
+            .appendingPathComponent("images", isDirectory: true)
+    }
+
+    private var directoryEnsured = false
+
+    // MARK: - Directory Setup
+
+    /// Ensure images directory exists (called lazily on first access)
+    private func ensureDirectory() throws {
+        guard !directoryEnsured else { return }
+        try FileManager.default.createDirectory(at: imagesDirectory, withIntermediateDirectories: true)
+        directoryEnsured = true
+    }
+
+    // MARK: - Save
+
+    /// Save a single image attachment to disk, returning an ImageRef
+    /// Skips writing if the file already exists (idempotent for re-saves)
+    func save(_ attachment: ImageAttachment) throws -> ImageRef {
+        try ensureDirectory()
+
+        let ref = ImageRef(from: attachment)
+        let fileURL = imagesDirectory.appendingPathComponent(ref.filename)
+
+        if !FileManager.default.fileExists(atPath: fileURL.path) {
+            try attachment.imageData.write(to: fileURL, options: .atomic)
+        }
+
+        return ref
+    }
+
+    /// Save multiple image attachments to disk
+    func save(_ attachments: [ImageAttachment]) throws -> [ImageRef] {
+        try attachments.map { try save($0) }
+    }
+
+    // MARK: - Load
+
+    /// Load full image data for an ImageRef
+    func loadImageData(for ref: ImageRef) throws -> Data {
+        try ensureDirectory()
+
+        let fileURL = imagesDirectory.appendingPathComponent(ref.filename)
+
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw ImagePersistenceError.imageNotFound(ref.filename)
+        }
+
+        return try Data(contentsOf: fileURL)
+    }
+
+    /// Restore a full ImageAttachment from an ImageRef
+    func restore(from ref: ImageRef) throws -> ImageAttachment {
+        let imageData = try loadImageData(for: ref)
+        let thumbnailData = ref.thumbnailData ?? Data()
+        let format = ref.imageFormat ?? .jpeg
+
+        return ImageAttachment(
+            id: ref.id,
+            imageData: imageData,
+            thumbnailData: thumbnailData,
+            originalFilename: ref.originalFilename,
+            width: ref.width,
+            height: ref.height,
+            fileSize: imageData.count,
+            format: format,
+            mimeType: format.mimeType,
+            sourceType: .clipboard // Source type not preserved in ref; default to clipboard
+        )
+    }
+
+    /// Restore multiple ImageAttachments from ImageRefs
+    /// Returns successfully restored attachments; logs failures for individual refs
+    func restore(from refs: [ImageRef]) -> [ImageAttachment] {
+        var attachments: [ImageAttachment] = []
+        for ref in refs {
+            do {
+                let attachment = try restore(from: ref)
+                attachments.append(attachment)
+            } catch {
+                print("[ImagePersistence] Warning: Failed to restore image \(ref.filename): \(error)")
+            }
+        }
+        return attachments
+    }
+
+    // MARK: - Delete
+
+    /// Delete image file for an ImageRef
+    func delete(ref: ImageRef) throws {
+        let fileURL = imagesDirectory.appendingPathComponent(ref.filename)
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try FileManager.default.removeItem(at: fileURL)
+        }
+    }
+
+    // MARK: - Cleanup
+
+    /// Remove orphaned image files that are not referenced by any active session
+    /// Returns the count of files removed
+    func cleanupOrphaned(activeRefs: Set<String>) throws -> Int {
+        try ensureDirectory()
+
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(atPath: imagesDirectory.path) else {
+            return 0
+        }
+
+        var removedCount = 0
+        for filename in files {
+            if !activeRefs.contains(filename) {
+                let fileURL = imagesDirectory.appendingPathComponent(filename)
+                try? fm.removeItem(at: fileURL)
+                removedCount += 1
+            }
+        }
+
+        return removedCount
+    }
+}
+
+// MARK: - Errors
+
+enum ImagePersistenceError: Error, LocalizedError {
+    case imageNotFound(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .imageNotFound(let filename):
+            return "Image file not found: \(filename)"
+        }
+    }
+}

--- a/Extremis/scripts/run-tests.sh
+++ b/Extremis/scripts/run-tests.sh
@@ -246,6 +246,26 @@ run_test_suite "Design System Tests" \
     "$PROJECT_DIR/Tests/UI/DesignSystemTests.swift" \
     "Foundation"
 
+# 29. ImageAttachment Model Tests (Codable, Equatable, ImageFormat, ImageSourceType, ImageRef)
+run_test_suite "ImageAttachment Model Tests" \
+    "$PROJECT_DIR/Tests/Core/ImageAttachmentTests.swift" \
+    "Foundation"
+
+# 30. ImageProcessor Tests (format validation, size validation, dimension calculations)
+run_test_suite "ImageProcessor Tests" \
+    "$PROJECT_DIR/Tests/Core/ImageProcessorTests.swift" \
+    "Foundation"
+
+# 31. ImagePersistence Tests (save/load, file naming, delete, missing file handling)
+run_test_suite "ImagePersistence Tests" \
+    "$PROJECT_DIR/Tests/Utilities/ImagePersistenceTests.swift" \
+    "Foundation"
+
+# 32. PromptBuilder Multimodal Tests (OpenAI, Anthropic, Gemini, Ollama image formatting)
+run_test_suite "PromptBuilder Multimodal Tests" \
+    "$PROJECT_DIR/Tests/LLMProviders/PromptBuilderImageTests.swift" \
+    "Foundation"
+
 # ------------------------------------------------------------------------------
 # Final Summary
 # ------------------------------------------------------------------------------

--- a/specs/012-image-attachments/checklists/requirements.md
+++ b/specs/012-image-attachments/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Image Attachments
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-19
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation on first iteration.
+- Clarification pass (2026-05-19): 3 questions asked and resolved — Quick Mode scope, Magic Mode scope, text requirement with images.
+- Spec is ready for `/speckit.plan`.

--- a/specs/012-image-attachments/contracts/image-persistence.md
+++ b/specs/012-image-attachments/contracts/image-persistence.md
@@ -1,0 +1,63 @@
+# Contract: ImagePersistence
+
+**Module**: `Utilities/ImagePersistence.swift`
+**Type**: `actor` (thread-safe file I/O)
+
+## Public Interface
+
+```swift
+actor ImagePersistence {
+    static let shared = ImagePersistence()
+
+    /// Directory for stored images.
+    /// ~/Library/Application Support/Extremis/images/
+    var imagesDirectory: URL { get }
+
+    /// Save an ImageAttachment's full-resolution data to disk.
+    /// - Returns: ImageRef for persistence in PersistedMessage
+    func save(_ attachment: ImageAttachment) throws -> ImageRef
+
+    /// Save multiple attachments.
+    func save(_ attachments: [ImageAttachment]) throws -> [ImageRef]
+
+    /// Load full-resolution image data by reference.
+    func loadImageData(for ref: ImageRef) throws -> Data
+
+    /// Restore an ImageAttachment from an ImageRef (loads full image from disk).
+    func restore(from ref: ImageRef) throws -> ImageAttachment
+
+    /// Restore multiple ImageAttachments from refs.
+    func restore(from refs: [ImageRef]) throws -> [ImageAttachment]
+
+    /// Delete image file from disk.
+    func delete(ref: ImageRef) throws
+
+    /// Remove orphaned image files not referenced by any active session.
+    /// - Parameter activeRefs: Set of image IDs currently referenced by sessions
+    func cleanupOrphaned(activeRefs: Set<UUID>) throws -> Int
+}
+```
+
+## Behavior Contract
+
+1. **Directory creation**: `imagesDirectory` is created on first access if it doesn't exist.
+2. **File naming**: Images stored as `{uuid}.{format}` (e.g., `abc123.jpg`).
+3. **Atomic writes**: Use `Data.write(to:options:.atomic)` to prevent corruption.
+4. **Thumbnail in ref**: `ImageRef.thumbnailBase64` is set from `ImageAttachment.thumbnailData` at save time — no separate thumbnail file.
+5. **Restoration**: `restore(from:)` loads file data and reconstructs `ImageAttachment` using ref metadata (dimensions, format, filename).
+6. **Missing files**: If image file is missing on restore, throw error but don't crash — caller should handle gracefully (show placeholder).
+7. **Cleanup**: `cleanupOrphaned()` is called during session garbage collection. It scans `imagesDirectory` and deletes files not in `activeRefs`.
+8. **Thread safety**: Actor isolation ensures concurrent save/load operations don't corrupt state.
+
+## File Layout
+
+```text
+~/Library/Application Support/Extremis/
+├── sessions/
+│   ├── {session-id-1}.json    # PersistedSession with imageRefs
+│   └── {session-id-2}.json
+└── images/
+    ├── {uuid-1}.jpg
+    ├── {uuid-2}.jpg
+    └── {uuid-3}.png
+```

--- a/specs/012-image-attachments/contracts/image-processor.md
+++ b/specs/012-image-attachments/contracts/image-processor.md
@@ -1,0 +1,78 @@
+# Contract: ImageProcessor
+
+**Module**: `Core/Services/ImageProcessor.swift`
+**Type**: `@MainActor final class` (singleton via `.shared`)
+
+## Public Interface
+
+```swift
+@MainActor
+final class ImageProcessor {
+    static let shared = ImageProcessor()
+
+    // MARK: - Configuration Constants
+    static let maxImageLongEdge: Int = 1568
+    static let maxImageFileSize: Int = 4_194_304      // 4MB
+    static let maxInputImageSize: Int = 10_485_760     // 10MB
+    static let maxImagesPerMessage: Int = 5
+    static let thumbnailMaxSize: Int = 200
+    static let jpegQuality: CGFloat = 0.85
+    static let thumbnailJpegQuality: CGFloat = 0.6
+
+    // MARK: - Supported Formats
+    static let supportedUTTypes: [UTType] = [.png, .jpeg, .gif, .webP, .heic]
+
+    // MARK: - Processing
+
+    /// Process raw image data into a send-ready ImageAttachment.
+    /// Resizes, compresses, converts format, and generates thumbnail.
+    /// - Parameters:
+    ///   - data: Raw input image data (any supported format)
+    ///   - sourceType: How the image was attached (clipboard/filePicker/dragAndDrop)
+    ///   - originalFilename: Original filename if available
+    /// - Returns: Processed ImageAttachment ready for display and sending
+    /// - Throws: ImageProcessingError
+    func process(
+        data: Data,
+        sourceType: ImageSourceType,
+        originalFilename: String?
+    ) throws -> ImageAttachment
+
+    /// Validate that input data is a supported image format and within size limits.
+    /// - Returns: true if valid
+    func validate(data: Data) -> Result<Void, ImageProcessingError>
+
+    /// Generate a thumbnail from existing image data.
+    /// - Parameters:
+    ///   - data: Processed image data (JPEG/PNG)
+    ///   - maxSize: Maximum pixel dimension on longest edge
+    /// - Returns: Thumbnail data as JPEG
+    func generateThumbnail(from data: Data, maxSize: Int) -> Data?
+
+    /// Convert image data to base64 string for LLM API transmission.
+    func base64Encode(_ data: Data) -> String
+}
+```
+
+## Error Type
+
+```swift
+enum ImageProcessingError: LocalizedError {
+    case unsupportedFormat(String)      // "TIFF files are not supported"
+    case inputTooLarge(Int)             // Exceeds maxInputImageSize
+    case processingFailed(String)       // ImageIO operation failed
+    case outputTooLarge(Int)            // After compression, still exceeds maxImageFileSize
+
+    var errorDescription: String? { ... }
+}
+```
+
+## Behavior Contract
+
+1. **Input validation**: Reject data >10MB or unsupported formats before processing.
+2. **Format detection**: Use `CGImageSourceGetType()` to determine input format from data (not filename extension).
+3. **Resizing**: Only resize if either dimension exceeds `maxImageLongEdge`. Maintain aspect ratio. Use `CGImageSourceCreateThumbnailAtIndex` for memory efficiency.
+4. **Format conversion**: HEIC, GIF, WebP → JPEG. PNG with alpha → PNG. PNG without alpha → JPEG.
+5. **Compression**: Apply `jpegQuality` for JPEG output. If result exceeds `maxImageFileSize`, retry at 0.7 quality.
+6. **Thumbnail**: Always generate 200px thumbnail at 0.6 JPEG quality regardless of output format.
+7. **Thread safety**: All operations are synchronous and pure — no shared mutable state.

--- a/specs/012-image-attachments/contracts/provider-formatting.md
+++ b/specs/012-image-attachments/contracts/provider-formatting.md
@@ -1,0 +1,104 @@
+# Contract: Provider Multimodal Message Formatting
+
+**Module**: Each provider in `LLMProviders/`
+**Coordination**: `LLMProviders/PromptBuilder.swift`
+
+## PromptBuilder Extension
+
+```swift
+extension PromptBuilder {
+    /// Format a ChatMessage's content for multimodal API requests.
+    /// Returns structured content when images are present, plain string when not.
+    /// - Parameters:
+    ///   - message: The ChatMessage to format
+    /// - Returns: Either a String (text-only) or [[String: Any]] (multimodal)
+    func formatMessageContent(_ message: ChatMessage) -> Any
+
+    /// Format all chat messages, handling multimodal content.
+    /// Returns [[String: Any]] where "content" may be String or Array.
+    func formatChatMessagesMultimodal(messages: [ChatMessage]) -> [[String: Any]]
+}
+```
+
+## Per-Provider Content Block Formats
+
+### OpenAI
+
+```json
+{
+  "role": "user",
+  "content": [
+    {"type": "text", "text": "Describe this image"},
+    {
+      "type": "image_url",
+      "image_url": {
+        "url": "data:image/jpeg;base64,{base64data}",
+        "detail": "auto"
+      }
+    }
+  ]
+}
+```
+
+**Notes**: When content is text-only, continues to use `"content": "string"` format (backward compatible). The `detail` parameter defaults to `"auto"`.
+
+### Anthropic
+
+```json
+{
+  "role": "user",
+  "content": [
+    {
+      "type": "image",
+      "source": {
+        "type": "base64",
+        "media_type": "image/jpeg",
+        "data": "{base64data}"
+      }
+    },
+    {"type": "text", "text": "Describe this image"}
+  ]
+}
+```
+
+**Notes**: Images should be placed BEFORE text in the content array for best results (per Anthropic docs). System prompt remains separate (not in messages array).
+
+### Gemini
+
+```json
+{
+  "role": "user",
+  "parts": [
+    {
+      "inlineData": {
+        "mimeType": "image/jpeg",
+        "data": "{base64data}"
+      }
+    },
+    {"text": "Describe this image"}
+  ]
+}
+```
+
+**Notes**: Gemini uses `parts` array instead of `content`. Each part is either `text` or `inlineData`.
+
+### Ollama
+
+```json
+{
+  "role": "user",
+  "content": "Describe this image",
+  "images": ["{raw_base64_no_prefix}"]
+}
+```
+
+**Notes**: Ollama uses a separate `images` field (not content blocks). Base64 data must NOT include the `data:image/...;base64,` prefix. Content remains a plain string. Multiple images go as separate array elements.
+
+## Behavior Contract
+
+1. **Backward compatibility**: Text-only messages MUST use the existing format (string content) — no content arrays for text-only.
+2. **Image ordering**: Images placed before text in content blocks (Anthropic best practice, works for all providers).
+3. **Multiple images**: All images from `message.imageAttachments` are included as separate content blocks/parts.
+4. **Image-only messages**: When text is empty and images are present, omit the text content block entirely (per FR-018 + clarification: no injected prompt).
+5. **Non-vision models**: If model lacks `supportsVision`, image attachments are silently stripped from the message before formatting (defense in depth — UI should prevent this).
+6. **Base64 encoding**: Use `ImageProcessor.base64Encode()` for consistent encoding.

--- a/specs/012-image-attachments/contracts/ui-components.md
+++ b/specs/012-image-attachments/contracts/ui-components.md
@@ -1,0 +1,94 @@
+# Contract: UI Components for Image Attachments
+
+**Module**: `UI/PromptWindow/`
+
+## ImageAttachmentView
+
+**File**: `UI/PromptWindow/ImageAttachmentView.swift`
+**Type**: SwiftUI `View`
+
+Displays a horizontal strip of thumbnail previews for pending image attachments.
+
+```swift
+struct ImageAttachmentView: View {
+    let attachments: [ImageAttachment]
+    let onRemove: (UUID) -> Void
+
+    // Renders:
+    // - Horizontal ScrollView of thumbnails (80-120px each)
+    // - Each thumbnail has an "X" dismiss button (top-right corner)
+    // - Label below each: originalFilename ?? "Pasted image"
+    // - Uses DS.Radii.medium for thumbnail corners
+    // - Uses DS.Spacing.sm between thumbnails
+    // - Uses DS.Colors.borderSubtle for thumbnail border
+}
+```
+
+## ImageDropZoneView
+
+**File**: `UI/PromptWindow/ImageDropZoneView.swift`
+**Type**: SwiftUI `View`
+
+Overlay that appears when user drags an image file over the input area.
+
+```swift
+struct ImageDropZoneView: View {
+    let isTargeted: Bool
+
+    // Renders:
+    // - Semi-transparent overlay (DS.Colors.surfacePrimary at 0.8 opacity)
+    // - Dashed border (DS.Colors.borderFocused)
+    // - "Drop images here" text with image icon
+    // - Animated appearance/disappearance (DS.Animation.standard)
+    // - Only visible when isTargeted == true
+}
+```
+
+## ChatInputView Modifications
+
+**File**: `UI/PromptWindow/ChatInputView.swift` (existing)
+
+### New Properties
+
+```swift
+@Binding var pendingAttachments: [ImageAttachment]
+let supportsVision: Bool  // From current model's capabilities
+```
+
+### New UI Elements
+
+1. **Attachment button**: Paperclip icon to the left of send button. Hidden when `!supportsVision`.
+2. **Attachment strip**: `ImageAttachmentView` shown above text editor when `pendingAttachments` is non-empty.
+3. **Drop zone**: `.onDrop(of: [.image])` modifier on the entire input area.
+4. **Paste handler**: Intercept Cmd+V to check for image content on NSPasteboard.
+
+### Send Button Behavior Change
+
+Currently: enabled when text is non-empty.
+New: enabled when text is non-empty OR `pendingAttachments` is non-empty (FR-018).
+
+### Non-Vision Model Behavior
+
+- Attachment button: hidden
+- Paste image: show brief toast "Current model doesn't support images"
+- Drag image: drop zone doesn't activate
+
+## Chat Bubble Image Display
+
+**File**: `UI/PromptWindow/ChatBubbleView.swift` (or equivalent existing message view)
+
+### Image Rendering in History
+
+- Display images as inline thumbnails (max 300px width) above message text
+- Multiple images: 2-column grid layout
+- Click thumbnail: show full-size image via Quick Look popover or NSPanel
+- Images use DS.Radii.medium corner radius
+- Aspect ratio preserved
+
+## Behavior Contract
+
+1. **All DS tokens**: Use DesignSystem tokens for colors, spacing, radii, shadows. No hardcoded values.
+2. **Responsive**: Thumbnail strip scrolls horizontally for >3 images. No layout jumps.
+3. **Accessibility**: Thumbnails have accessibility labels ("Attached image: {filename}"). Remove buttons are keyboard accessible.
+4. **Animation**: Drop zone uses DS.Animation.standard for enter/exit. Thumbnail addition/removal uses default SwiftUI transitions.
+5. **Chat Mode only**: All image attachment UI is gated on Chat Mode (FR-019). Quick Mode and Magic Mode show no attachment controls.

--- a/specs/012-image-attachments/data-model.md
+++ b/specs/012-image-attachments/data-model.md
@@ -1,0 +1,164 @@
+# Data Model: Image Attachments
+
+**Feature**: 012-image-attachments
+**Date**: 2026-05-19
+
+## Entities
+
+### ImageAttachment
+
+Represents a single image attached to a chat message.
+
+| Field | Type | Description | Constraints |
+|-------|------|-------------|-------------|
+| id | UUID | Unique identifier | Required, auto-generated |
+| imageData | Data | Full-resolution processed image (JPEG/PNG) | Required, max 4MB after processing |
+| thumbnailData | Data | Small preview image (200px, JPEG 0.6) | Required, generated from imageData, typically 5-15KB |
+| originalFilename | String? | Original filename if from file picker/drag-drop | Optional, nil for clipboard pastes |
+| width | Int | Image width in pixels (after processing) | Required, max 1568 |
+| height | Int | Image height in pixels (after processing) | Required, max 1568 |
+| fileSize | Int | Size of imageData in bytes | Required |
+| format | ImageFormat | Output format (jpeg or png) | Required |
+| mimeType | String | MIME type string (e.g., "image/jpeg") | Required, derived from format |
+| sourceType | ImageSourceType | How the image was attached | Required |
+| createdAt | Date | Timestamp of attachment | Required, auto-generated |
+
+**Lifecycle**: Created on attach → stored in pending attachments → embedded in ChatMessage on send → persisted to disk on session save → restored on session load.
+
+### ImageFormat (Enum)
+
+| Case | Raw Value | MIME Type | Use Case |
+|------|-----------|-----------|----------|
+| jpeg | "jpeg" | "image/jpeg" | Photos, screenshots, most images |
+| png | "png" | "image/png" | Images with transparency |
+
+### ImageSourceType (Enum)
+
+| Case | Raw Value | Description |
+|------|-----------|-------------|
+| clipboard | "clipboard" | Pasted from clipboard (Cmd+V) |
+| filePicker | "file_picker" | Selected via NSOpenPanel |
+| dragAndDrop | "drag_and_drop" | Dropped onto the window |
+
+### ImageRef (Persistence Reference)
+
+Stored in `PersistedMessage` to reference images on disk.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | UUID | Matches ImageAttachment.id |
+| filename | String | Filename on disk (e.g., "{uuid}.jpg") |
+| thumbnailBase64 | String | Base64-encoded thumbnail for fast preview |
+| originalFilename | String? | Original filename for display |
+| width | Int | Image width |
+| height | Int | Image height |
+| format | String | "jpeg" or "png" |
+
+### VisionCapability (Model Configuration Extension)
+
+Extension to existing `LLMModel` and `models.json`.
+
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| supportsVision | Bool | Whether the model accepts image inputs | false |
+
+Added to the existing `capabilities` object in `models.json` alongside `supportsTools`.
+
+## Modified Entities
+
+### ChatMessage (Existing — Extended)
+
+| New Field | Type | Description |
+|-----------|------|-------------|
+| imageAttachments | [ImageAttachment]? | Optional array of attached images, nil for text-only messages |
+
+**Backward compatibility**: Property is optional with nil default. Existing text-only messages are unaffected. Codable conformance handles missing field gracefully.
+
+### PersistedMessage (Existing — Extended)
+
+| New Field | Type | Description |
+|-----------|------|-------------|
+| imageRefs | [ImageRef]? | Optional array of image file references with inline thumbnails |
+
+**Backward compatibility**: Optional field. Existing persisted sessions without images load normally.
+
+## Relationships
+
+```text
+ChatMessage 1 ──── 0..* ImageAttachment
+    │
+    └── (persisted as)
+    │
+PersistedMessage 1 ──── 0..* ImageRef
+    │                         │
+    │                         └── references file at:
+    │                             ~/Library/Application Support/Extremis/images/{id}.{format}
+    │
+    └── (part of)
+    │
+PersistedSession
+```
+
+## State Transitions
+
+### ImageAttachment Lifecycle
+
+```text
+[Created] ──attach──→ [Pending]
+                         │
+                    send message
+                         │
+                         ▼
+                    [Sent] ──save session──→ [Persisted]
+                         │                        │
+                    display in                load session
+                    chat history                   │
+                         │                         ▼
+                         └─────────────────── [Restored]
+
+[Pending] ──remove──→ [Discarded] (image data released)
+[Pending] ──send fails──→ [Pending] (preserved for retry)
+```
+
+### Vision Capability State
+
+```text
+Model selected → Check supportsVision
+    │
+    ├── true  → Show attachment controls, enable paste/drop
+    │
+    └── false → Hide attachment controls, show toast on paste attempt
+```
+
+## Storage Layout
+
+```text
+~/Library/Application Support/Extremis/
+├── sessions/
+│   └── {session-id}.json          # Contains PersistedMessage with ImageRef[]
+└── images/
+    ├── {uuid-1}.jpg               # Full-resolution processed image
+    ├── {uuid-2}.jpg
+    └── {uuid-3}.png               # PNG for transparency images
+```
+
+## Validation Rules
+
+1. **Format validation**: Input must be PNG, JPEG, GIF, WebP, or HEIC. Others rejected with user notification.
+2. **Size validation**: Input images >10MB trigger a warning. After processing, images must be <4MB.
+3. **Count validation**: Maximum 5 images per message. Attempts to add more show limit notification.
+4. **Dimension processing**: Images exceeding 1568px on longest edge are resized proportionally.
+5. **Format conversion**: HEIC, GIF, and WebP inputs are converted to JPEG (or PNG if transparency detected).
+6. **Vision gate**: Images can only be attached when active model has `supportsVision: true`.
+
+## Configuration Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| maxImageLongEdge | 1568 | Maximum pixels on longest edge after resize |
+| maxImageFileSize | 4,194,304 | Maximum bytes per image after processing (4MB) |
+| maxInputImageSize | 10,485,760 | Maximum bytes for input image before processing (10MB) |
+| maxImagesPerMessage | 5 | Maximum images per single message |
+| thumbnailMaxSize | 200 | Maximum pixels on longest edge for thumbnails |
+| jpegQuality | 0.85 | JPEG compression quality for full images |
+| thumbnailJpegQuality | 0.6 | JPEG compression quality for thumbnails |

--- a/specs/012-image-attachments/plan.md
+++ b/specs/012-image-attachments/plan.md
@@ -1,0 +1,166 @@
+# Implementation Plan: Image Attachments
+
+**Branch**: `012-image-attachments` | **Date**: 2026-05-19 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/012-image-attachments/spec.md`
+
+## Summary
+
+Add image attachment support to Extremis Chat Mode, allowing users to paste, drag-and-drop, or pick image files and send them to vision-capable LLMs. The feature includes vision capability detection per model, a thumbnail preview strip in the input area, provider-specific multimodal message formatting, and file-based image persistence for session restoration. All changes are additive — existing text-only flows remain untouched.
+
+## Technical Context
+
+**Language/Version**: Swift 5.9+
+**Primary Dependencies**: AppKit (NSPasteboard, NSDragging), ImageIO (CGImageSource for efficient resizing/thumbnailing), SwiftUI
+**Storage**: File-based image storage in `~/Library/Application Support/Extremis/images/`, JSON session persistence with file references and inline thumbnails
+**Testing**: Standalone Swift test files using `TestRunner` pattern (per project conventions), added to `scripts/run-tests.sh`
+**Target Platform**: macOS 13.0+ (Ventura)
+**Project Type**: Single macOS app (Swift Package Manager)
+**Performance Goals**: Image thumbnail renders in <1s, image attachment + send in <5s, UI remains responsive (60fps) during image processing
+**Constraints**: Images resized to max 1568px long edge, compressed to <1MB JPEG before sending; max 5 images per message; Chat Mode only
+**Scale/Scope**: Single-user desktop app, ~5-10 images per conversation typical
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Modularity & Separation of Concerns | PASS | Image processing, persistence, and UI are separate modules. New `ImageAttachment` model, `ImageProcessor` service, and `ImageAttachmentView` are independent components. No circular dependencies. |
+| II. Code Quality & Best Practices | PASS | Follows Swift API Design Guidelines. Uses ImageIO (industry best practice) for resizing. Named constants for size limits and dimensions. |
+| III. Extensibility & Testability | PASS | `supportsVision` capability flag follows existing `supportsTools` pattern. Image processing is pure function (testable). Provider-specific formatting is per-provider (extensible). |
+| IV. User Experience Excellence | PASS | Instant thumbnail feedback (<1s). Clear vision capability indicators. Drop zone visual feedback. Non-intrusive error messages. |
+| V. Documentation Synchronization | PASS | README and docs will be updated when feature ships. |
+| VI. Testing Discipline | PASS | Unit tests for image processing, model capability detection, persistence, and message formatting. Edge case tests for format conversion, size limits. |
+| VII. Regression Prevention | PASS | All changes additive. Existing text-only flows untouched. `ChatMessage` extended (not modified). Provider message formatting adds image branch without changing text path. |
+
+**Quality Standards Gate**:
+- Build: Compiles without warnings (verified per phase)
+- Tests: All existing + new tests pass
+- Manual QA: Text-only hotkey flows verified after each phase
+- Performance: UI responsive during image processing
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-image-attachments/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (internal contracts)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+Extremis/
+├── Core/
+│   ├── Models/
+│   │   ├── ChatMessage.swift        # MODIFY: Add imageAttachments property
+│   │   ├── ImageAttachment.swift    # NEW: ImageAttachment model
+│   │   └── Persistence/
+│   │       └── PersistedMessage.swift  # MODIFY: Add image references
+│   ├── Services/
+│   │   └── ImageProcessor.swift     # NEW: Resize, compress, thumbnail, format conversion
+│   └── Protocols/
+│       └── LLMProvider.swift        # NO CHANGE (messages still [ChatMessage])
+├── LLMProviders/
+│   ├── PromptBuilder.swift          # MODIFY: Format multimodal content blocks
+│   ├── OpenAIProvider.swift         # MODIFY: Add vision message format
+│   ├── AnthropicProvider.swift      # MODIFY: Add multimodal message format
+│   ├── GeminiProvider.swift         # MODIFY: Add inlineData parts
+│   └── OllamaProvider.swift         # MODIFY: Add images array support
+├── UI/
+│   ├── PromptWindow/
+│   │   ├── ChatInputView.swift      # MODIFY: Add attachment strip, drop zone, paste handling
+│   │   ├── ImageAttachmentView.swift    # NEW: Thumbnail preview strip component
+│   │   ├── ImageDropZoneView.swift      # NEW: Drop zone overlay
+│   │   └── PromptWindowController.swift # MODIFY: Wire image state to chat flow
+│   └── Components/
+│       └── DesignSystem.swift       # MINOR: Add image-related tokens if needed
+├── Utilities/
+│   └── ImagePersistence.swift       # NEW: Save/load images to Application Support
+├── Resources/
+│   └── models.json                  # MODIFY: Add supportsVision capability
+└── Tests/
+    ├── Core/
+    │   ├── ImageAttachmentTests.swift   # NEW
+    │   └── ImageProcessorTests.swift    # NEW
+    ├── LLMProviders/
+    │   └── PromptBuilderImageTests.swift # NEW
+    └── Utilities/
+        └── ImagePersistenceTests.swift  # NEW
+```
+
+**Structure Decision**: Follows existing Extremis directory conventions. New files are placed in their natural module locations. All changes are additive — no files are deleted or renamed.
+
+## Complexity Tracking
+
+No constitution violations. All changes follow existing patterns.
+
+## Implementation Phases
+
+### Phase 1: Core Image Model & Processing (Foundation)
+
+**Goal**: Establish the image data model, processing pipeline, and persistence layer without touching any UI or LLM provider code.
+
+**Changes**:
+1. `ImageAttachment` model — ID, imageData, thumbnailData, filename, dimensions, fileSize, format, mimeType
+2. `ImageProcessor` service — resize (max 1568px), compress (JPEG 0.85), thumbnail (200px), HEIC→JPEG conversion, format validation
+3. `ImagePersistence` utility — save images to `~/Library/Application Support/Extremis/images/{uuid}.jpg`, load by ID, cleanup orphaned images
+4. `models.json` — add `"supportsVision": true/false` to model capabilities
+5. `LLMModel` — read and expose `supportsVision` capability
+6. Unit tests for all of the above
+
+**Regression check**: Zero UI or provider changes. Existing flows unaffected.
+
+### Phase 2: Provider Multimodal Message Formatting
+
+**Goal**: Enable each LLM provider to format and send image content blocks alongside text, without changing the LLM provider protocol.
+
+**Changes**:
+1. `ChatMessage` — add optional `imageAttachments: [ImageAttachment]?` property (additive, nil by default)
+2. `PersistedMessage` — add `imageRefs: [ImageRef]?` for file-based persistence with inline thumbnail data
+3. `PromptBuilder` — new `formatMultimodalContent()` method that returns `[[String: Any]]` when images present, `[[String: String]]` when not
+4. Per-provider formatting:
+   - OpenAI: content array with `image_url` type (base64 data URI)
+   - Anthropic: content array with `image` type and base64 source
+   - Gemini: parts array with `inlineData`
+   - Ollama: separate `images` array field (raw base64, no prefix)
+5. Unit tests for each provider's multimodal message formatting
+
+**Regression check**: Text-only messages continue using existing `[[String: String]]` path. Provider changes are in new code branches (if images present).
+
+### Phase 3: UI — Image Attachment Input
+
+**Goal**: Add the visual components for attaching, previewing, and removing images in Chat Mode's input area.
+
+**Changes**:
+1. `ImageAttachmentView` — horizontal thumbnail strip (80-120px thumbnails, X button to remove, "Pasted image" or filename label)
+2. `ImageDropZoneView` — semi-transparent overlay with dashed border on drag enter
+3. `ChatInputView` modifications:
+   - Cmd+V paste handler: detect image on NSPasteboard, create ImageAttachment
+   - `.onDrop` handler: accept image UTTypes, create ImageAttachments
+   - Attachment button (paperclip icon): open NSOpenPanel filtered to image UTTypes
+   - Show/hide attachment controls based on `supportsVision` capability
+   - Allow send with images-only (no text required per FR-018)
+4. `PromptWindowController` — wire pending image attachments into ChatMessage creation
+5. Vision capability feedback: hide attach button for non-vision models, show brief toast if user attempts paste
+
+**Regression check**: Quick Mode and Magic Mode untouched (FR-019). Text-only Chat Mode flow preserved. Attachment strip only appears when images are attached.
+
+### Phase 4: Conversation History & Persistence
+
+**Goal**: Display images in chat history and persist them across sessions.
+
+**Changes**:
+1. Chat bubble image rendering — inline thumbnails (max 300px wide), click to view full-size via macOS Quick Look or popover
+2. Multiple images in a bubble — grid layout (2 columns for 2-4 images)
+3. Session persistence — on save: write image files via `ImagePersistence`, store `ImageRef` (UUID + thumbnail base64) in `PersistedMessage`; on load: restore `ImageAttachment` from file refs
+4. Failed send preservation — keep pending attachments on error (FR-016)
+5. Integration tests for full flow: attach → send → display → save → reload → display
+
+**Regression check**: Text-only conversations persist and load identically. Image files are additive storage.

--- a/specs/012-image-attachments/quickstart.md
+++ b/specs/012-image-attachments/quickstart.md
@@ -1,0 +1,119 @@
+# Quickstart: Image Attachments
+
+**Feature**: 012-image-attachments
+**Branch**: `012-image-attachments`
+
+## Prerequisites
+
+- macOS 13.0+ (Ventura)
+- Swift 5.9+
+- Existing Extremis build environment (`swift build` succeeds on `main`)
+
+## Implementation Order
+
+Work through these phases sequentially. Each phase is independently buildable and testable. Run `./scripts/run-tests.sh` after each phase to verify no regressions.
+
+### Phase 1: Core Image Model & Processing
+
+1. Create `Extremis/Core/Models/ImageAttachment.swift`
+   - `ImageAttachment` struct (Codable, Identifiable, Equatable)
+   - `ImageFormat` enum
+   - `ImageSourceType` enum
+   - `ImageRef` struct for persistence
+
+2. Create `Extremis/Core/Services/ImageProcessor.swift`
+   - Singleton service with processing pipeline
+   - Uses `ImageIO` framework (import `ImageIO`, `UniformTypeIdentifiers`)
+   - Key function: `process(data:sourceType:originalFilename:) throws -> ImageAttachment`
+   - Resize via `CGImageSourceCreateThumbnailAtIndex`
+   - HEIC/WebP/GIF → JPEG conversion via `CGImageDestination`
+   - Thumbnail generation
+
+3. Create `Extremis/Utilities/ImagePersistence.swift`
+   - Actor for thread-safe file I/O
+   - Save/load/delete images in `~/Library/Application Support/Extremis/images/`
+
+4. Update `Extremis/Resources/models.json`
+   - Add `"supportsVision": true/false` to each model's capabilities
+   - Update `LLMModel` to read the new field
+
+5. Write tests:
+   - `Tests/Core/ImageAttachmentTests.swift`
+   - `Tests/Core/ImageProcessorTests.swift`
+   - `Tests/Utilities/ImagePersistenceTests.swift`
+   - Add all to `scripts/run-tests.sh`
+
+**Verify**: `swift build` succeeds, all tests pass, no existing tests broken.
+
+### Phase 2: Provider Multimodal Formatting
+
+1. Extend `ChatMessage` — add `imageAttachments: [ImageAttachment]?`
+2. Extend `PersistedMessage` — add `imageRefs: [ImageRef]?`
+3. Extend `PromptBuilder` — add `formatChatMessagesMultimodal()` method
+4. Update each provider's request builder:
+   - `OpenAIProvider` — content array with `image_url` type
+   - `AnthropicProvider` — content array with `image` + base64 source
+   - `GeminiProvider` — parts array with `inlineData`
+   - `OllamaProvider` — separate `images` field
+5. Write tests:
+   - `Tests/LLMProviders/PromptBuilderImageTests.swift`
+   - Add to `scripts/run-tests.sh`
+
+**Verify**: `swift build` succeeds, text-only message formatting unchanged, all tests pass.
+
+### Phase 3: UI — Image Input
+
+1. Create `Extremis/UI/PromptWindow/ImageAttachmentView.swift` — thumbnail strip
+2. Create `Extremis/UI/PromptWindow/ImageDropZoneView.swift` — drop zone overlay
+3. Modify `ChatInputView.swift`:
+   - Add pending attachments state
+   - Clipboard paste interception (NSPasteboard image detection)
+   - `.onDrop` modifier for drag-and-drop
+   - Attachment button (paperclip icon) → NSOpenPanel
+   - Vision capability gating
+4. Modify `PromptWindowController.swift`:
+   - Wire pending attachments into message creation
+   - Pass `supportsVision` from current model to ChatInputView
+
+**Verify**: Build succeeds, paste/drop/pick all create thumbnails, text-only flow unchanged.
+
+### Phase 4: History Display & Persistence
+
+1. Update chat bubble view — inline image thumbnails, click-to-expand
+2. Update session save — `ImagePersistence.save()` + `ImageRef` in `PersistedMessage`
+3. Update session load — `ImagePersistence.restore()` from `ImageRef`
+4. Error handling — preserve attachments on send failure, placeholder on missing image file
+
+**Verify**: Full flow works: attach → send → display → save → quit → relaunch → display.
+
+## Key Files Reference
+
+| File | Action | Phase |
+|------|--------|-------|
+| `Core/Models/ImageAttachment.swift` | NEW | 1 |
+| `Core/Services/ImageProcessor.swift` | NEW | 1 |
+| `Utilities/ImagePersistence.swift` | NEW | 1 |
+| `Resources/models.json` | MODIFY | 1 |
+| `Core/Models/ChatMessage.swift` | MODIFY | 2 |
+| `Core/Models/Persistence/PersistedMessage.swift` | MODIFY | 2 |
+| `LLMProviders/PromptBuilder.swift` | MODIFY | 2 |
+| `LLMProviders/OpenAIProvider.swift` | MODIFY | 2 |
+| `LLMProviders/AnthropicProvider.swift` | MODIFY | 2 |
+| `LLMProviders/GeminiProvider.swift` | MODIFY | 2 |
+| `LLMProviders/OllamaProvider.swift` | MODIFY | 2 |
+| `UI/PromptWindow/ImageAttachmentView.swift` | NEW | 3 |
+| `UI/PromptWindow/ImageDropZoneView.swift` | NEW | 3 |
+| `UI/PromptWindow/ChatInputView.swift` | MODIFY | 3 |
+| `UI/PromptWindow/PromptWindowController.swift` | MODIFY | 3 |
+| Chat bubble view | MODIFY | 4 |
+| `Core/Services/JSONSessionStorage.swift` | MODIFY | 4 |
+
+## Running Tests
+
+```bash
+# All tests
+cd Extremis && ./scripts/run-tests.sh
+
+# Single test file
+swiftc -parse-as-library Tests/Core/ImageProcessorTests.swift -o /tmp/test && /tmp/test
+```

--- a/specs/012-image-attachments/research.md
+++ b/specs/012-image-attachments/research.md
@@ -1,0 +1,115 @@
+# Research: Image Attachments
+
+**Feature**: 012-image-attachments
+**Date**: 2026-05-19
+
+## Decision 1: Image Encoding Format for LLM APIs
+
+**Decision**: Use base64 encoding for all providers. Each provider gets its own content block format.
+
+**Rationale**: All four supported providers (OpenAI, Anthropic, Gemini, Ollama) accept base64-encoded images. URL-based approaches require hosting infrastructure. Base64 is self-contained, works offline (important for Ollama), and requires no external dependencies.
+
+**Provider-specific formats**:
+
+| Provider | Format | Content Structure |
+|----------|--------|-------------------|
+| OpenAI | Data URI in `image_url` | `{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,{data}", "detail": "auto"}}` |
+| Anthropic | Explicit base64 source | `{"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "{data}"}}` |
+| Gemini | Inline data part | `{"inlineData": {"mimeType": "image/jpeg", "data": "{data}"}}` |
+| Ollama | Separate images array | Message gets `"images": ["{raw_base64}"]` field (no data URI prefix) |
+
+**Alternatives considered**:
+- URL-based hosting: Requires server infrastructure, doesn't work offline. Rejected.
+- File upload APIs (OpenAI Files, Anthropic Files): Adds complexity for marginal benefit in a desktop app. Could be added later.
+
+## Decision 2: Image Resizing Strategy
+
+**Decision**: Resize to max 1568px on the longest edge using ImageIO framework. Compress to JPEG at 0.85 quality. Target <1MB per image after processing.
+
+**Rationale**: 1568px covers all providers comfortably (Anthropic's optimal limit for non-Opus models is 1568px, OpenAI high detail goes up to 2048px but auto-tiles, Gemini tiles at 768px). ImageIO's `CGImageSourceCreateThumbnailAtIndex` is the most memory-efficient approach on macOS — a 20MB image only requires ~24MB RAM when downsampled via ImageIO vs ~220MB when fully decoded first.
+
+**Alternatives considered**:
+- Core Graphics (`CGContext.draw`): Slightly faster but higher memory usage for large images. Rejected for memory efficiency.
+- vImage/Core Image: Much slower (2.3-2.5s vs 0.16s). Rejected.
+- No resizing (send original): Risk of exceeding API limits (Anthropic 5MB/image) and wasting tokens. Rejected.
+
+## Decision 3: Image Persistence Strategy
+
+**Decision**: Hybrid approach — store full-resolution processed images as files in `~/Library/Application Support/Extremis/images/{uuid}.jpg`. Store thumbnail as inline base64 in the persisted message JSON for fast preview rendering.
+
+**Rationale**: File-based storage keeps JSON session files small and fast to parse. Inline thumbnails (~5-15KB each as base64) enable instant preview on session restore without file I/O. This is the pattern used by production chat apps (Slack, Discord).
+
+**Alternatives considered**:
+- Full base64 inline in JSON: Bloats session files (a 10-image conversation adds 3-5MB to JSON), slows parsing. Rejected.
+- File references only (no inline thumbnail): Requires file I/O for every thumbnail on session load, slower perceived startup. Rejected.
+
+## Decision 4: Thumbnail Dimensions and Format
+
+**Decision**: Generate thumbnails at 200px on the longest edge, JPEG at 0.6 quality. Typical size: 5-15KB.
+
+**Rationale**: 200px thumbnails are sufficient for the 80-120px display size in the attachment strip (provides 1.5-2.5x for Retina). JPEG at 0.6 keeps size under 15KB while remaining visually acceptable for preview purposes.
+
+**Alternatives considered**:
+- 100px thumbnails: Too small for Retina displays. Rejected.
+- PNG thumbnails: 3-5x larger file size for no visual benefit at thumbnail size. Rejected.
+
+## Decision 5: Vision Capability Detection
+
+**Decision**: Add `"supportsVision": true/false` to the `capabilities` object in `models.json`, consistent with existing `supportsTools` pattern. For Ollama, use a heuristic based on known vision model families.
+
+**Rationale**: Static metadata in `models.json` is simple, reliable, and follows the established pattern. Ollama doesn't expose vision capability via API, so a heuristic (model names containing "llava", "vision", "gemma3", etc.) is the practical approach.
+
+**Known vision models by provider**:
+- OpenAI: gpt-4o, gpt-4o-mini, gpt-4-turbo (all current models)
+- Anthropic: claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-3.5-sonnet, claude-3.5-haiku, claude-4-opus, claude-4-sonnet (all Claude 3+ models)
+- Gemini: gemini-1.5-pro, gemini-1.5-flash, gemini-2.0-flash (all current models)
+- Ollama: llava, llama3.2-vision, gemma3, qwen3-vl (varies by model)
+
+**Alternatives considered**:
+- Runtime API query (`/v1/models` endpoint): Only OpenAI exposes this reliably. Adds network dependency. Rejected for initial implementation.
+- User toggle per model: More flexible but adds UX burden. Could be added later for Ollama custom models.
+
+## Decision 6: Supported Image Formats
+
+**Decision**: Accept PNG, JPEG, GIF (non-animated), WebP, HEIC/HEIF at input. Convert HEIC to JPEG before sending. Send as JPEG for photos/screenshots, PNG for images with transparency.
+
+**Rationale**: macOS ImageIO natively reads all these formats. HEIC is common on macOS (screenshots, Photos.app exports). All providers accept JPEG and PNG. Gemini is the only provider that natively accepts HEIC, but converting to JPEG ensures universal compatibility.
+
+**Alternatives considered**:
+- HEIC passthrough to Gemini: Would complicate the pipeline for marginal benefit. Rejected.
+- Support animated GIF: Adds complexity (multi-frame handling) for a niche use case. Rejected for initial scope.
+
+## Decision 7: API Size Limits per Provider
+
+**Decision**: Apply a universal 4MB-per-image limit after processing (well within all providers' limits). Display error if an image exceeds 10MB before processing and cannot be compressed below 4MB.
+
+| Provider | Image Size Limit | Request Size Limit |
+|----------|-----------------|-------------------|
+| OpenAI | 512MB (generous) | 512MB |
+| Anthropic | 5MB per image | 32MB request |
+| Gemini | 20MB inline | 20MB request |
+| Ollama | Undocumented | Internal resize |
+
+**Rationale**: Anthropic's 5MB limit is the most restrictive. A 4MB universal limit provides safety margin. With resizing to 1568px and JPEG 0.85, virtually all images will be well under 1MB.
+
+## Decision 8: Clipboard Handling Behavior
+
+**Decision**: On Cmd+V, check NSPasteboard for image types first (TIFF, PNG, JPEG). If an image is found, attach it. If only text is found, paste text as normal. If both are present, attach the image AND paste the text.
+
+**Rationale**: NSPasteboard can contain multiple types simultaneously (e.g., a webpage copy may have both HTML text and a rendered image). Handling both ensures no data loss. This matches the behavior specified in the spec's edge cases.
+
+**macOS clipboard image types to check** (in priority order):
+1. `public.tiff` (NSPasteboard's native image format)
+2. `public.png`
+3. `public.jpeg`
+4. `public.heic`
+
+## Decision 9: Maximum Images per Message
+
+**Decision**: Default maximum of 5 images per message. Configurable constant but not user-facing preference initially.
+
+**Rationale**: 5 images covers common comparison scenarios (2-3 images) with headroom. Anthropic's limit is 20 on claude.ai and 100+ via API. OpenAI supports up to 1,500. 5 is a conservative, sensible default that prevents token budget issues.
+
+**Alternatives considered**:
+- 10 images: More generous but increases token cost significantly. Could be raised later.
+- Provider-specific limits: Adds complexity. Rejected for initial scope.

--- a/specs/012-image-attachments/spec.md
+++ b/specs/012-image-attachments/spec.md
@@ -1,0 +1,159 @@
+# Feature Specification: Image Attachments
+
+**Feature Branch**: `012-image-attachments`
+**Created**: 2026-05-19
+**Status**: Draft
+**Input**: User description: "Build the functionality to attach images, paste images and then feed it to llm if it supports in extremis"
+
+## Clarifications
+
+### Session 2026-05-19
+
+- Q: How should Quick Mode (Option+Space with selection) handle images, given it auto-generates without a text input step? → A: Quick Mode remains text-only; image attachments are only available in Chat Mode.
+- Q: Should Magic Mode (Option+Tab) support image-based summarization? → A: Out of scope; Magic Mode remains text-only.
+- Q: Can users send an image with no accompanying text? → A: Yes, image-only sends are allowed with no injected default prompt; the LLM handles it as-is.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Paste Image from Clipboard (Priority: P1)
+
+A user copies a screenshot or image to their clipboard and wants to include it in their conversation with the LLM. They open the Extremis prompt window and paste the image (Cmd+V). The image appears as a thumbnail preview in the input area. When they send their message, the image is included alongside the text and the LLM analyzes or responds based on the image content.
+
+**Why this priority**: Pasting images from the clipboard is the fastest and most common way users share visual content. Screenshots are a primary use case for a context-aware assistant — users want to ask about what they see on screen.
+
+**Independent Test**: Can be fully tested by copying any image to clipboard, pasting into the prompt window, and sending a message. Delivers immediate value by enabling visual context in conversations.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has an image on the clipboard, **When** they press Cmd+V in the prompt input area, **Then** a thumbnail preview of the image appears attached to the input area.
+2. **Given** the user has pasted an image and typed a question, **When** they press Enter to send, **Then** the message is sent to the LLM with both the text and image content.
+3. **Given** the user has pasted an image, **When** they click a remove/dismiss button on the image preview, **Then** the image is removed from the pending attachments.
+4. **Given** the user has pasted an image, **When** the image is displayed in the conversation history, **Then** it appears as a properly sized thumbnail that can be viewed at full size.
+
+---
+
+### User Story 2 - Attach Image via File Picker (Priority: P2)
+
+A user wants to attach an existing image file from their disk. They click an attachment button in the input area, which opens a file picker dialog. They select one or more image files, which appear as thumbnail previews. The images are included when the message is sent.
+
+**Why this priority**: File attachment is the standard secondary method for sharing images. It covers cases where the image isn't on the clipboard — such as saved screenshots, design mockups, or reference images.
+
+**Independent Test**: Can be fully tested by clicking the attach button, selecting an image file, and sending a message with it. Delivers value by supporting pre-existing image files.
+
+**Acceptance Scenarios**:
+
+1. **Given** the prompt window is open, **When** the user clicks the attachment button, **Then** a file picker dialog appears filtered to supported image formats.
+2. **Given** the file picker is open, **When** the user selects one or more image files, **Then** thumbnail previews appear in the input area for each selected image.
+3. **Given** multiple images are attached, **When** the user sends the message, **Then** all images are included with the message to the LLM.
+
+---
+
+### User Story 3 - Drag and Drop Image (Priority: P2)
+
+A user drags an image file from Finder or another application into the Extremis prompt window. The image is accepted and appears as a thumbnail preview, ready to be sent with the next message.
+
+**Why this priority**: Drag and drop is a natural macOS interaction pattern that complements paste and file picker. It shares implementation with the file attachment flow and provides a convenient alternative.
+
+**Independent Test**: Can be fully tested by dragging an image file onto the prompt window and verifying it appears as an attachment.
+
+**Acceptance Scenarios**:
+
+1. **Given** the prompt window is open, **When** the user drags an image file over the input area, **Then** a visual drop zone indicator appears.
+2. **Given** the drop zone is active, **When** the user drops the image file, **Then** a thumbnail preview appears in the input area.
+3. **Given** the user drags a non-image file over the input area, **When** they attempt to drop it, **Then** the drop is rejected and an appropriate message is shown.
+
+---
+
+### User Story 4 - Vision Capability Detection (Priority: P1)
+
+The system detects whether the currently selected LLM provider and model supports image/vision inputs. If the model does not support images, the image attachment controls are hidden or disabled, and the user is informed if they attempt to attach an image.
+
+**Why this priority**: This is critical for preventing user frustration — attempting to send images to a text-only model would result in errors or silent failures. Users need clear feedback about what their current model supports.
+
+**Independent Test**: Can be fully tested by switching between vision-capable and text-only models and verifying the UI updates accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has selected a vision-capable model, **When** the prompt window opens, **Then** the image attachment button is visible and paste/drop are enabled.
+2. **Given** the user has selected a text-only model, **When** the prompt window opens, **Then** the image attachment button is hidden or disabled.
+3. **Given** the user has selected a text-only model, **When** they attempt to paste an image, **Then** a brief, non-intrusive notification informs them that the current model does not support images.
+4. **Given** the user switches from a vision-capable model to a text-only model mid-conversation, **When** images were previously sent in the conversation, **Then** the conversation history still displays the images but new image attachments are disabled.
+
+---
+
+### User Story 5 - Multiple Images in a Single Message (Priority: P3)
+
+A user attaches multiple images to a single message — through any combination of paste, file picker, and drag-and-drop. All images appear as a scrollable row of thumbnails and are sent together with the text message.
+
+**Why this priority**: While single image attachment covers most use cases, supporting multiple images enables comparison scenarios (e.g., "which design looks better?") and richer context sharing.
+
+**Independent Test**: Can be fully tested by attaching 2+ images via different methods and verifying all are sent and displayed.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has attached one image, **When** they paste or attach another image, **Then** both images appear as thumbnails in the input area.
+2. **Given** multiple images are attached, **When** the user removes one image, **Then** the remaining images stay attached.
+3. **Given** the user attaches more images than the maximum allowed, **When** they attempt to add another, **Then** they are informed of the limit and the additional image is not added.
+
+---
+
+### Edge Cases
+
+- What happens when the user pastes a very large image (e.g., 50MB+)? The system should resize/compress images above a reasonable size threshold before sending to the LLM, and inform the user if the image exceeds the maximum allowed size after compression.
+- What happens when the user pastes non-image clipboard content (e.g., text, files)? Text paste should continue to work as normal; non-image files should be ignored for image attachment.
+- What happens when the LLM provider's connection fails mid-upload? The message should fail gracefully with an appropriate error, and the user's text and image attachments should be preserved for retry.
+- What happens when the user pastes an image in Quick Mode (with text selection)? Quick Mode is text-only; image paste is ignored and text paste continues to work as normal.
+- What happens when the clipboard contains both text and an image? The system should attach the image and insert the text separately, allowing both to be sent.
+- How does image attachment interact with the conversation persistence system? Images should be persisted as part of the conversation history so they are available when sessions are restored.
+- What happens when a user drags multiple files at once, some of which are not images? Only the valid image files should be accepted; non-image files should be silently ignored.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST allow users to paste images from the clipboard into the prompt input area using Cmd+V.
+- **FR-002**: System MUST allow users to attach image files via a file picker dialog accessible from an attachment button in the input area.
+- **FR-003**: System MUST allow users to drag and drop image files into the prompt window.
+- **FR-004**: System MUST display attached images as thumbnail previews in the input area before sending.
+- **FR-005**: System MUST allow users to remove individual attached images before sending.
+- **FR-006**: System MUST send attached images to the LLM alongside the text message when the user submits.
+- **FR-007**: System MUST detect whether the active LLM provider and model supports image/vision inputs.
+- **FR-008**: System MUST hide or disable image attachment controls when the active model does not support images.
+- **FR-009**: System MUST inform the user with a brief notification when they attempt to attach an image to a non-vision model.
+- **FR-010**: System MUST display sent images in the conversation history as viewable thumbnails.
+- **FR-011**: System MUST support attaching multiple images to a single message, up to a configurable maximum (default: 5).
+- **FR-012**: System MUST support common image formats: PNG, JPEG, GIF, WebP, HEIC.
+- **FR-013**: System MUST resize or compress images that exceed a size threshold (10MB) before sending to the LLM.
+- **FR-014**: System MUST show a visual drop zone indicator when an image file is dragged over the prompt window.
+- **FR-015**: System MUST persist image attachments as part of conversation history for session restoration.
+- **FR-016**: System MUST preserve the user's text and image attachments if sending fails, allowing retry.
+- **FR-017**: System MUST continue to handle text-only paste (Cmd+V) as normal when no image is on the clipboard.
+- **FR-018**: System MUST allow users to send a message containing only image(s) with no accompanying text.
+- **FR-019**: System MUST limit image attachment support to Chat Mode only; Quick Mode and Magic Mode remain text-only.
+
+### Key Entities
+
+- **ImageAttachment**: Represents a single image attached to a message. Key attributes: unique identifier, image data, original filename (if from file), dimensions, file size, format, thumbnail representation.
+- **VisionCapability**: Represents whether a given LLM provider/model combination supports image inputs. Associated with the model configuration.
+- **AttachmentGroup**: Represents the collection of images attached to a single pending message. Tracks count against maximum limit.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can attach an image (via paste, file picker, or drag-and-drop) and send it with a message in under 5 seconds.
+- **SC-002**: Image thumbnails render in the input area within 1 second of attachment.
+- **SC-003**: 100% of image attachment attempts to non-vision models result in clear user feedback (no silent failures).
+- **SC-004**: Users can attach and send up to 5 images in a single message without performance degradation.
+- **SC-005**: Images persist correctly across session save and restore — 100% of images in conversation history are viewable after reopening a session.
+- **SC-006**: All three attachment methods (paste, file picker, drag-and-drop) work independently and can be used in combination within a single message.
+- **SC-007**: Images above the size threshold are automatically processed and sent successfully without user intervention.
+
+## Assumptions
+
+- LLM providers that support vision (e.g., OpenAI GPT-4o, Anthropic Claude 3+, Google Gemini) accept base64-encoded images or image URLs in their message payloads. The specific encoding format will be determined during implementation.
+- The maximum number of images per message (default 5) is a reasonable limit that balances usability with provider constraints. This can be adjusted per-provider if needed.
+- Image compression/resizing to stay under 10MB is sufficient for all supported LLM providers' size limits.
+- HEIC format images (common on macOS) will be converted to a universally supported format (e.g., JPEG/PNG) before sending to providers.
+- The existing conversation persistence system can be extended to store image data (either inline or as file references).
+- Only Chat Mode supports image attachments. Quick Mode and Magic Mode remain text-only to preserve their instant, no-input-required workflows.

--- a/specs/012-image-attachments/tasks.md
+++ b/specs/012-image-attachments/tasks.md
@@ -1,0 +1,267 @@
+# Tasks: Image Attachments
+
+**Input**: Design documents from `/specs/012-image-attachments/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Included — unit tests requested for all components.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **macOS app**: `Extremis/` at repository root (Swift Package Manager)
+- **Tests**: `Extremis/Tests/` organized by module
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Project structure and model configuration
+
+- [x] T001 Add `supportsVision` capability flag to all models in `Extremis/Resources/models.json` (true for GPT-4o, GPT-4o-mini, GPT-4-turbo, all Claude 3+, all Gemini models; false for others)
+- [x] T002 Update `LLMModel` to read `supportsVision` from capabilities in the model config struct (wherever `supportsTools` is read, add `supportsVision` alongside it)
+- [x] T003 Create images storage directory helper — ensure `~/Library/Application Support/Extremis/images/` is created on first use (add to existing Application Support directory setup)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core data model, image processing pipeline, persistence layer, and provider formatting that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+### Tests for Foundational Phase
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T004 [P] Create `ImageAttachment` model unit tests in `Extremis/Tests/Core/ImageAttachmentTests.swift` — test Codable round-trip, Equatable conformance, ImageFormat/ImageSourceType enums, ImageRef creation from ImageAttachment
+- [x] T005 [P] Create `ImageProcessor` unit tests in `Extremis/Tests/Core/ImageProcessorTests.swift` — test format validation (accept PNG/JPEG/GIF/WebP/HEIC, reject TIFF/BMP), size validation (reject >10MB input), thumbnail generation (output <=200px), resize logic (output <=1568px), JPEG compression quality, base64 encoding
+- [x] T006 [P] Create `ImagePersistence` unit tests in `Extremis/Tests/Utilities/ImagePersistenceTests.swift` — test save/load round-trip, restore from ImageRef, delete, file naming convention ({uuid}.{format}), missing file handling
+- [x] T007 [P] Create `PromptBuilder` multimodal formatting tests in `Extremis/Tests/LLMProviders/PromptBuilderImageTests.swift` — test text-only messages unchanged, OpenAI vision format, Anthropic multimodal format, Gemini inlineData format, Ollama images array format, image-only message (no text), multiple images per message, non-vision model strips images
+- [x] T008 Add all new test files (T004-T007) to `Extremis/scripts/run-tests.sh`
+
+### Implementation for Foundational Phase
+
+- [x] T009 [P] Create `ImageAttachment` model in `Extremis/Core/Models/ImageAttachment.swift` — struct with id (UUID), imageData (Data), thumbnailData (Data), originalFilename (String?), width (Int), height (Int), fileSize (Int), format (ImageFormat enum: jpeg/png), mimeType (String), sourceType (ImageSourceType enum: clipboard/filePicker/dragAndDrop), createdAt (Date). Must be Codable, Identifiable, Equatable.
+- [x] T010 [P] Create `ImageRef` persistence struct in `Extremis/Core/Models/ImageAttachment.swift` (same file) — struct with id (UUID), filename (String), thumbnailBase64 (String), originalFilename (String?), width (Int), height (Int), format (String). Must be Codable. Add convenience init from ImageAttachment.
+- [x] T011 Create `ImageProcessor` service in `Extremis/Core/Services/ImageProcessor.swift` — @MainActor singleton with: configuration constants (maxImageLongEdge=1568, maxImageFileSize=4MB, maxInputImageSize=10MB, maxImagesPerMessage=5, thumbnailMaxSize=200, jpegQuality=0.85, thumbnailJpegQuality=0.6), supportedUTTypes, `process(data:sourceType:originalFilename:) throws -> ImageAttachment`, `validate(data:) -> Result<Void, ImageProcessingError>`, `generateThumbnail(from:maxSize:) -> Data?`, `base64Encode(_:) -> String`. Use ImageIO framework (CGImageSourceCreateThumbnailAtIndex) for memory-efficient resizing. HEIC/GIF/WebP → JPEG conversion. PNG with alpha → PNG, else → JPEG. ImageProcessingError enum with unsupportedFormat, inputTooLarge, processingFailed, outputTooLarge cases.
+- [x] T012 Create `ImagePersistence` actor in `Extremis/Utilities/ImagePersistence.swift` — actor with: imagesDirectory URL (~/Library/Application Support/Extremis/images/), `save(_:) throws -> ImageRef`, `save(_:[ImageAttachment]) throws -> [ImageRef]`, `loadImageData(for:) throws -> Data`, `restore(from:) throws -> ImageAttachment`, `restore(from:[ImageRef]) throws -> [ImageAttachment]`, `delete(ref:) throws`, `cleanupOrphaned(activeRefs:) throws -> Int`. Atomic file writes. Create directory on first access.
+- [x] T013 Extend `ChatMessage` in `Extremis/Core/Models/ChatMessage.swift` — add optional `imageAttachments: [ImageAttachment]?` property with nil default. Ensure Codable and Equatable conformance still works. Existing text-only messages must be unaffected.
+- [x] T014 Extend `PersistedMessage` in `Extremis/Core/Models/Persistence/PersistedMessage.swift` — add optional `imageRefs: [ImageRef]?` property. Update encoding/decoding to handle optional field gracefully (backward compatible with existing sessions).
+- [x] T015 Extend `PromptBuilder` in `Extremis/LLMProviders/PromptBuilder.swift` — add `formatChatMessagesMultimodal(messages:) -> [[String: Any]]` method. When a message has imageAttachments, return content as array of content blocks. When text-only, return content as String (existing behavior). Images placed before text in content blocks.
+- [x] T016 [P] Update `OpenAIProvider` in `Extremis/LLMProviders/OpenAIProvider.swift` — modify request builders (buildChatRequest and tool variants) to use `formatChatMessagesMultimodal`. For messages with images: content becomes array with `{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,{data}", "detail": "auto"}}` blocks. Text-only messages use existing String format.
+- [x] T017 [P] Update `AnthropicProvider` in `Extremis/LLMProviders/AnthropicProvider.swift` — modify request builders to use multimodal formatting. For messages with images: content becomes array with `{"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": "{data}"}}` blocks. Images before text per Anthropic docs.
+- [x] T018 [P] Update `GeminiProvider` in `Extremis/LLMProviders/GeminiProvider.swift` — modify request builders to use multimodal formatting. For messages with images: parts array gets `{"inlineData": {"mimeType": "image/jpeg", "data": "{data}"}}` entries.
+- [x] T019 [P] Update `OllamaProvider` in `Extremis/LLMProviders/OllamaProvider.swift` — modify request builders. For messages with images: add separate `"images": ["{raw_base64}"]` field to message dict. Content remains plain string. No data URI prefix on base64.
+- [x] T020 Verify all existing tests pass — run `cd Extremis && ./scripts/run-tests.sh` and confirm zero regressions. Verify `swift build` compiles without warnings.
+
+**Checkpoint**: Foundation ready — image processing pipeline, persistence, provider formatting, and model capability all functional. User story implementation can now begin.
+
+---
+
+## Phase 3: User Story 4 — Vision Capability Detection (Priority: P1)
+
+**Goal**: Detect whether the active model supports images and gate the UI accordingly. This is P1 and must be done before other UI stories since all attachment UI depends on vision capability gating.
+
+**Independent Test**: Switch between vision-capable and text-only models; verify attachment controls appear/disappear.
+
+### Implementation for User Story 4
+
+- [x] T021 [US4] Expose `supportsVision` on the active provider/model — ensure the current model's vision capability is accessible from wherever `ChatInputView` and `PromptWindowController` read model state. Follow the same pattern used for `supportsTools`.
+- [x] T022 [US4] Add vision capability gating to `ChatInputView` in `Extremis/UI/PromptWindow/ChatInputView.swift` — accept a `supportsVision: Bool` parameter. When false: hide attachment button, disable image paste/drop handlers. When true: show attachment controls. No visual changes yet (attachment UI built in US1).
+- [x] T023 [US4] Add non-vision model notification — when user attempts to paste an image (Cmd+V with image on clipboard) and `supportsVision` is false, show a brief non-intrusive toast/notification: "Current model doesn't support images". Use existing notification/toast pattern if available, or add minimal toast component.
+- [x] T024 [US4] Wire `supportsVision` from model config through `PromptWindowController` in `Extremis/UI/PromptWindow/PromptWindowController.swift` — pass the active model's `supportsVision` to `ChatInputView`. Update when model changes mid-conversation.
+
+**Checkpoint**: Vision capability detection works — model switching correctly shows/hides image controls.
+
+---
+
+## Phase 4: User Story 1 — Paste Image from Clipboard (Priority: P1) — MVP
+
+**Goal**: Users can paste images from clipboard into Chat Mode, see a thumbnail preview, send with a message, and see the image in conversation history.
+
+**Independent Test**: Copy any image to clipboard, open Chat Mode, press Cmd+V, see thumbnail, type a question, press Enter — image and text sent to vision-capable LLM, response received, image visible in chat history.
+
+### Implementation for User Story 1
+
+- [x] T025 [P] [US1] Create `ImageAttachmentView` thumbnail strip in `Extremis/UI/PromptWindow/ImageAttachmentView.swift` — horizontal ScrollView of thumbnails (80-120px), each with "X" dismiss button (top-right), label below (originalFilename ?? "Pasted image"). Use DS.Radii.medium for corners, DS.Spacing.sm between thumbnails, DS.Colors.borderSubtle for border. Accept `attachments: [ImageAttachment]` and `onRemove: (UUID) -> Void`.
+- [x] T026 [US1] Add clipboard paste image detection to `ChatInputView` in `Extremis/UI/PromptWindow/ChatInputView.swift` — intercept Cmd+V: check NSPasteboard.general for image types (public.tiff, public.png, public.jpeg, public.heic). If image found: process via ImageProcessor.shared.process(), add to pending attachments array. If both text and image on clipboard: attach image AND paste text. If only text: existing paste behavior unchanged (FR-017).
+- [x] T027 [US1] Add pending attachments state and thumbnail strip to `ChatInputView` — add `@State var pendingAttachments: [ImageAttachment]` (or @Binding from parent). Show `ImageAttachmentView` above text editor when non-empty. Update send button: enabled when text is non-empty OR pendingAttachments is non-empty (FR-018). Allow image-only sends with no text.
+- [x] T028 [US1] Wire pending attachments into message creation in `PromptWindowController` in `Extremis/UI/PromptWindow/PromptWindowController.swift` — when creating ChatMessage on send, attach pendingAttachments to the message's imageAttachments property. Clear pending attachments after successful send. Preserve pending attachments on send failure (FR-016).
+- [x] T029 [US1] Add image display in chat history bubbles — in the existing chat message/bubble view, render image thumbnails (max 300px width, aspect ratio preserved) above message text when `message.imageAttachments` is non-empty. Use DS.Radii.medium for image corners. Click thumbnail to view full-size (Quick Look popover or NSPanel).
+- [x] T030 [US1] Add image session persistence — update session save flow: call `ImagePersistence.shared.save()` for each message's images, store `ImageRef` array in `PersistedMessage.imageRefs`. Update session load flow: call `ImagePersistence.shared.restore()` from `imageRefs` to reconstruct `ImageAttachment` objects. Handle missing image files gracefully (show placeholder).
+- [x] T031 [US1] Run full regression test — `cd Extremis && ./scripts/run-tests.sh`, verify `swift build` clean, manually test: paste image → thumbnail appears → send → response received → image in history → quit → relaunch → image still visible. Also verify text-only Chat Mode, Quick Mode, and Magic Mode all work unchanged.
+
+**Checkpoint**: MVP complete — users can paste images from clipboard, send to vision-capable LLMs, see images in chat history, and images persist across sessions.
+
+---
+
+## Phase 5: User Story 2 — Attach Image via File Picker (Priority: P2)
+
+**Goal**: Users can click an attachment button to open a file picker and select image files to attach.
+
+**Independent Test**: Open Chat Mode with vision-capable model, click paperclip button, select an image file, see thumbnail, send message.
+
+### Implementation for User Story 2
+
+- [x] T032 [US2] Add attachment button (paperclip icon) to `ChatInputView` in `Extremis/UI/PromptWindow/ChatInputView.swift` — place to the left of send button. Only visible when `supportsVision` is true. Use SF Symbol "paperclip" or equivalent. Style with DS tokens.
+- [x] T033 [US2] Implement file picker action in `ChatInputView` — on attachment button tap, present `NSOpenPanel` with: allowedContentTypes filtered to supported image formats (PNG, JPEG, GIF, WebP, HEIC), allowsMultipleSelection = true. Process selected files through `ImageProcessor.shared.process()`, add to pendingAttachments.
+- [x] T034 [US2] Verify file picker integration — manually test: click attachment → pick single file → thumbnail appears → send. Pick multiple files → all thumbnails appear. Pick non-image file → rejected by type filter.
+
+**Checkpoint**: File picker attachment works independently alongside paste.
+
+---
+
+## Phase 6: User Story 3 — Drag and Drop Image (Priority: P2)
+
+**Goal**: Users can drag image files from Finder or other apps into the prompt window.
+
+**Independent Test**: Drag a JPEG from Finder onto the prompt input area, see drop zone indicator, drop, see thumbnail preview.
+
+### Implementation for User Story 3
+
+- [x] T035 [P] [US3] Create `ImageDropZoneView` overlay in `Extremis/UI/PromptWindow/ImageDropZoneView.swift` — semi-transparent overlay (DS.Colors.surfacePrimary at 0.8 opacity), dashed border (DS.Colors.borderFocused), centered "Drop images here" text with image icon. Only visible when isTargeted is true. Use DS.Animation.standard for enter/exit.
+- [x] T036 [US3] Add drag-and-drop support to `ChatInputView` in `Extremis/UI/PromptWindow/ChatInputView.swift` — add `.onDrop(of: [.image], isTargeted: $isDropTargeted)` modifier. On drop: load image data from NSItemProvider, process via ImageProcessor, add to pendingAttachments. Show `ImageDropZoneView` when isDropTargeted and supportsVision. Reject non-image drops.
+- [x] T037 [US3] Handle multi-file drops — when user drops multiple files at once, filter to valid image types only (silently ignore non-images per edge case spec). Process each valid image and add all to pendingAttachments.
+- [x] T038 [US3] Verify drag and drop — manually test: drag image over input → drop zone appears → drop → thumbnail appears. Drag non-image → drop zone doesn't activate (or drop rejected). Drag from Finder, drag from browser, drag from Preview.
+
+**Checkpoint**: All three attachment methods (paste, pick, drag) work independently and in combination.
+
+---
+
+## Phase 7: User Story 5 — Multiple Images in a Single Message (Priority: P3)
+
+**Goal**: Users can attach up to 5 images to a single message via any combination of methods.
+
+**Independent Test**: Attach 3+ images via different methods (paste one, pick one, drag one), all appear as thumbnails, send all together.
+
+### Implementation for User Story 5
+
+- [x] T039 [US5] Add image count limit enforcement in `ChatInputView` — when pendingAttachments.count reaches maxImagesPerMessage (5), show brief notification "Maximum 5 images per message" on further attach attempts. Disable attachment button at limit. Paste and drop also respect limit.
+- [x] T040 [US5] Make thumbnail strip horizontally scrollable — update `ImageAttachmentView` to handle >3 thumbnails gracefully. Ensure horizontal ScrollView works for 5 thumbnails without layout issues. Verify individual removal still works at any position.
+- [x] T041 [US5] Add multiple image grid layout in chat history — when a message has 2+ images, display in a 2-column grid layout within the chat bubble. Single image uses full-width layout. Preserve aspect ratios.
+- [x] T042 [US5] Verify multi-image flow — manually test: attach 5 images via mix of methods → all thumbnails visible and scrollable → remove middle image → 4 remain → send → grid layout in history → try to add 6th → blocked with notification.
+
+**Checkpoint**: All 5 user stories complete and working together.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final quality, documentation, and edge case hardening
+
+- [x] T043 [P] Update `README.md` and `Extremis/docs/` with image attachment feature documentation — supported formats, how to use, model requirements
+- [x] T044 [P] Update `CLAUDE.md` with new files, patterns, and architecture changes — add ImageAttachment, ImageProcessor, ImagePersistence to Key Files section, add image-related paths to Architecture section
+- [x] T045 Run orphaned image cleanup — call `ImagePersistence.cleanupOrphaned()` during session garbage collection (if such a mechanism exists) or on app launch
+- [x] T046 Edge case hardening — verify: very large image (>10MB) shows appropriate error, HEIC conversion works, clipboard with both text+image handles correctly, model switch mid-conversation disables new attachments but preserves history, failed send preserves attachments for retry
+- [x] T047 Run full test suite and manual QA — `cd Extremis && ./scripts/run-tests.sh`, manual test all hotkey flows (Option+Space Quick Mode, Option+Tab Magic Mode, Chat Mode with and without images), verify zero regressions
+- [x] T048 Run quickstart.md validation — walk through quickstart.md steps to confirm all phases are complete and all file paths are accurate
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **US4 Vision Detection (Phase 3)**: Depends on Foundational — BLOCKS UI user stories (US1, US2, US3, US5)
+- **US1 Clipboard Paste (Phase 4)**: Depends on US4 — MVP milestone
+- **US2 File Picker (Phase 5)**: Depends on US4 — can run parallel with US1 but easier after
+- **US3 Drag and Drop (Phase 6)**: Depends on US4 — can run parallel with US1/US2
+- **US5 Multiple Images (Phase 7)**: Depends on at least one attachment method (US1, US2, or US3) being complete
+- **Polish (Phase 8)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **US4 (Vision Detection)**: Foundational only — no story dependencies. Gates all other UI stories.
+- **US1 (Paste)**: US4 only — independently testable. **MVP target.**
+- **US2 (File Picker)**: US4 only — independently testable. Can parallelize with US1.
+- **US3 (Drag and Drop)**: US4 only — independently testable. Can parallelize with US1/US2.
+- **US5 (Multiple Images)**: At least one of US1/US2/US3 must be done to test meaningfully.
+
+### Within Each User Story
+
+- Tests (T004-T008) MUST be written first and FAIL before implementation
+- Models before services (T009-T010 before T011-T012)
+- Services before provider formatting (T011-T012 before T015-T019)
+- Foundation before UI (Phase 2 before Phase 3+)
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- **Phase 2**: T004-T007 (all test files) can run in parallel. T009-T010 (models) can run in parallel. T016-T019 (providers) can run in parallel after T015.
+- **Phase 4-6**: US1 (paste), US2 (file picker), US3 (drag-drop) can all run in parallel after US4 is done (if team capacity allows).
+- **Phase 8**: T043-T044 (documentation) can run in parallel.
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# Launch all test files in parallel:
+Task: "T004 - ImageAttachment model tests"
+Task: "T005 - ImageProcessor tests"
+Task: "T006 - ImagePersistence tests"
+Task: "T007 - PromptBuilder multimodal tests"
+
+# Launch all model files in parallel:
+Task: "T009 - ImageAttachment model"
+Task: "T010 - ImageRef persistence struct"
+
+# Launch all provider updates in parallel (after PromptBuilder):
+Task: "T016 - OpenAI multimodal"
+Task: "T017 - Anthropic multimodal"
+Task: "T018 - Gemini multimodal"
+Task: "T019 - Ollama multimodal"
+```
+
+## Parallel Example: UI Phases (after US4 complete)
+
+```bash
+# Can run US1, US2, US3 in parallel if desired:
+Task: "US1 - Clipboard paste (Phase 4)"
+Task: "US2 - File picker (Phase 5)"
+Task: "US3 - Drag and drop (Phase 6)"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + Vision Detection Only)
+
+1. Complete Phase 1: Setup (T001-T003)
+2. Complete Phase 2: Foundational (T004-T020)
+3. Complete Phase 3: US4 Vision Detection (T021-T024)
+4. Complete Phase 4: US1 Paste from Clipboard (T025-T031)
+5. **STOP and VALIDATE**: Paste image → send → see in history → persists across sessions
+6. Deploy/demo if ready — this is the MVP
+
+### Incremental Delivery
+
+1. Setup + Foundational → Core pipeline ready
+2. Add US4 (Vision Detection) → Capability gating ready
+3. Add US1 (Paste) → **MVP!** Test independently → Deploy
+4. Add US2 (File Picker) → Test independently → Deploy
+5. Add US3 (Drag and Drop) → Test independently → Deploy
+6. Add US5 (Multiple Images) → Test independently → Deploy
+7. Each story adds value without breaking previous stories
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- All code changes are additive — existing text-only flows must remain untouched
+- Run `./scripts/run-tests.sh` after every phase to catch regressions early
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Configuration constants (maxImagesPerMessage, jpegQuality, etc.) defined in ImageProcessor — single source of truth


### PR DESCRIPTION
## Summary

Add image attachment support to chat messages. Users can attach images via paste (Cmd+V), drag-and-drop, or file picker, and send them to vision-capable LLM models alongside text.

## Changes

- **ImageAttachment model** (`Core/Models/ImageAttachment.swift`) — `ImageAttachment` struct with COW `Data`, `ImageRef` for persistence, `ImageFormat`/`ImageSourceType` enums
- **ImageProcessor** (`Core/Services/ImageProcessor.swift`) — ImageIO-based processing: resize to 1568px max edge, JPEG/PNG compression, thumbnail generation, alpha detection
- **ImagePersistence** (`Utilities/ImagePersistence.swift`) — Actor-based file storage in `~/Library/Application Support/Extremis/images/`, save/load/delete/cleanup
- **ChatInputView** — Cmd+V paste interception via `performKeyEquivalent` (NSPanel doesn't fire `paste:`), drag-and-drop support, file picker button (visible when model supports vision), thumbnail strip with remove buttons
- **ImageAttachmentView** — Thumbnail strip for input, chat message image grid, click-to-expand with adaptive Quick Look-style viewer (75% screen, aspect ratio preserved)
- **ImageDropZoneView** — Drag-and-drop overlay with visual feedback
- **ChatMessageView** — Fixed hover button disappearing issue with debounced hover (generation counter pattern)
- **PromptBuilder** — Multimodal message formatting for all 4 providers (OpenAI, Anthropic, Gemini, Ollama) with inline base64 image content
- **All LLM providers** — Updated to pass image attachments through streaming APIs
- **Persistence** — `PersistedMessage` stores `ImageRef` array; `PersistedSession` saves/restores images via `ImagePersistence` actor
- **ChatMessage** — Added `imageAttachments`, `hasImages` properties
- **models.json** — Added `supportsVision` capability flag
- **Tests** — 4 new test suites: ImageAttachmentTests (57 tests), ImageProcessorTests, ImagePersistenceTests, PromptBuilderImageTests

## Related Issue

Closes #25

## Testing

- [x] Build passes (`swift build`)
- [x] All tests pass (`./scripts/run-tests.sh`) — 1882 tests across 33 suites
- [x] Manual testing completed (paste, drag-drop, file picker, expand view, persistence, multi-provider)

## Checklist

- [x] Code follows project conventions
- [x] No new warnings introduced
- [x] Documentation updated (if applicable)
- [x] CLAUDE.md updated (if new patterns/features added)