### PR TITLE
Add voice input via speech-to-text (#015)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,7 +239,7 @@ Latest completed feature: `specs/015-voice-input/` (Voice Input via SFSpeechReco
 - `Extremis/LLMProviders/CLIStreamParser.swift` - JSONL stream parser for Claude Code CLI events
 - `Extremis/Core/Models/VoiceInputModels.swift` - VoiceInputState enum, TranscriptionUpdate, VoiceInputConfiguration, VoicePermissionStatus, SpeechRecognitionError
 - `Extremis/Core/Services/VoiceInputManager.swift` - @MainActor singleton coordinator for voice input (start/stop/toggle recording, permission checks, silence/duration timers)
-- `Extremis/Core/Services/SpeechRecognitionService.swift` - AVAudioEngine + SFSpeechRecognizer wrapper, returns AsyncThrowingStream<TranscriptionUpdate, Error>
+- `Extremis/Core/Services/SpeechRecognitionService.swift` - AVCaptureSession + SFSpeechRecognizer wrapper (AVAudioEngine fallback), returns AsyncThrowingStream<TranscriptionUpdate, Error>
 - `Extremis/UI/PromptWindow/VoiceInputIndicator.swift` - Mic button component with recording state visualization (idle/recording/error)
 
 ## Configuration & Storage
@@ -372,11 +372,11 @@ MCP servers are configured in `~/Library/Application Support/Extremis/mcp-server
 - UserDefaults (stealth state and configuration) (013-stealth-mode)
 - Swift 5.9+ with Swift Concurrency + Foundation (Process, Pipe), SwiftUI + AppKit hybrid, existing LLMProvider protocol (014-claude-code-provider)
 - UserDefaults (model selection, binary path, allowed tools) (014-claude-code-provider)
-- Swift 5.9+ + Speech framework (SFSpeechRecognizer), AVFoundation (AVAudioEngine), Carbon (existing), ApplicationServices (existing) (015-voice-input)
+- Swift 5.9+ + Speech framework (SFSpeechRecognizer), AVFoundation (AVCaptureSession primary, AVAudioEngine fallback), CoreMedia, Carbon (existing), ApplicationServices (existing) (015-voice-input)
 - N/A — no audio or transcription persisted; text flows into existing ChatMessage pipeline (015-voice-input)
 
 ## Recent Changes
-- 015-voice-input: Voice-to-text input via Apple SFSpeechRecognizer with on-device recognition. Mic button in ChatInputView and PromptView. Option+D global hotkey to toggle recording. Live partial transcription streams into text field. Silence timeout (3s configurable), max duration (60s configurable). Permission handling with actionable System Settings guidance. Stops recording on app switch, Enter key, or manual toggle. Text appends to existing input (FR-012). UserDefaults-backed configuration.
+- 015-voice-input: Voice-to-text input via Apple SFSpeechRecognizer. Uses AVCaptureSession for audio capture (bypasses AVAudioEngine aggregate device bugs on macOS 26), with AVAudioEngine fallback. CMSampleBuffer→AVAudioPCMBuffer conversion via extension. Mic button in ChatInputView and PromptView. Option+D global hotkey to toggle recording. Live partial transcription streams into text field. Silence timeout (3s configurable), max duration (60s configurable). Permission handling with actionable System Settings guidance. Stops recording on app switch, Enter key, or manual toggle. Voice input disabled in stealth mode (macOS mic indicator cannot be hidden). Text appends to existing input. UserDefaults-backed configuration.
 - 014-claude-code-provider: Claude Code CLI as an LLM provider. Uses persistent subprocess with bidirectional NDJSON via `--input-format stream-json` and `--output-format stream-json`. No API key needed. User messages sent as JSON on stdin (`{"type":"user","message":{"role":"user","content":"..."}}`). Process started eagerly, stays alive across multi-turn conversation. Auto-restart on crash. Model aliases (sonnet/opus/haiku). Configurable allowed tools. Graceful cleanup on app quit.
 - 013-stealth-mode: Stealth mode makes Extremis invisible during screen sharing. Uses NSWindow.sharingType=.none for screen capture exclusion, collectionBehavior for Mission Control hiding, process name disguise, menu bar icon hiding. Toggle via Option+Shift+S hotkey. Configurable in Preferences. Adjustable window opacity with material blur (text stays readable). Sound notifications auto-suppressed in stealth. Screenshot button captures screen behind Extremis panel via CGWindowListCreateImage.
 - 012-image-attachments: Image attachments for chat messages via paste, drag-and-drop, and file picker. Uses ImageIO for processing, actor-based file persistence, and inline base64 thumbnails in session JSON.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Build
 cd Extremis && swift build
 
-# Run the app
+# Run the app (dev mode — creates .app bundle for TCC permissions)
+./scripts/run-dev.sh
+
+# Run bare binary (voice input / camera won't work — no Info.plist for TCC)
 swift run Extremis
-# OR after building:
-.build/debug/Extremis
 
 # Build release
 swift build -c release
@@ -47,6 +48,7 @@ swiftc -parse-as-library Extremis/Tests/Core/SessionManagerTests.swift -o /tmp/t
 Extremis is a macOS menu bar app that provides context-aware LLM text generation via global hotkeys:
 - **Option+Space**: Opens Quick Mode (with selection) or Chat Mode (without selection)
 - **Option+Tab**: Magic Mode - summarizes selected text (no-op without selection)
+- **Option+D**: Toggle voice input - starts/stops speech-to-text recording
 
 Context is captured via AX metadata (app name, window title) and selected text when present.
 
@@ -194,7 +196,7 @@ Feature specs are in `specs/` directory, each containing:
 - `tasks.md` - Task breakdown
 - `data-model.md` - Data model schemas (when applicable)
 
-Latest completed feature: `specs/014-claude-code-provider/` (Claude Code CLI Provider)
+Latest completed feature: `specs/015-voice-input/` (Voice Input via SFSpeechRecognizer)
 
 ## Key Files
 
@@ -235,6 +237,10 @@ Latest completed feature: `specs/014-claude-code-provider/` (Claude Code CLI Pro
 - `Extremis/LLMProviders/ClaudeCodeProvider.swift` - Claude Code CLI provider (LLMProvider conformance, tool approvals, process activation)
 - `Extremis/LLMProviders/ClaudeCodeProcessManager.swift` - Persistent CLI process lifecycle (start/stop/sendMessage, 6 safety rules)
 - `Extremis/LLMProviders/CLIStreamParser.swift` - JSONL stream parser for Claude Code CLI events
+- `Extremis/Core/Models/VoiceInputModels.swift` - VoiceInputState enum, TranscriptionUpdate, VoiceInputConfiguration, VoicePermissionStatus, SpeechRecognitionError
+- `Extremis/Core/Services/VoiceInputManager.swift` - @MainActor singleton coordinator for voice input (start/stop/toggle recording, permission checks, silence/duration timers)
+- `Extremis/Core/Services/SpeechRecognitionService.swift` - AVAudioEngine + SFSpeechRecognizer wrapper, returns AsyncThrowingStream<TranscriptionUpdate, Error>
+- `Extremis/UI/PromptWindow/VoiceInputIndicator.swift` - Mic button component with recording state visualization (idle/recording/error)
 
 ## Configuration & Storage
 
@@ -366,8 +372,11 @@ MCP servers are configured in `~/Library/Application Support/Extremis/mcp-server
 - UserDefaults (stealth state and configuration) (013-stealth-mode)
 - Swift 5.9+ with Swift Concurrency + Foundation (Process, Pipe), SwiftUI + AppKit hybrid, existing LLMProvider protocol (014-claude-code-provider)
 - UserDefaults (model selection, binary path, allowed tools) (014-claude-code-provider)
+- Swift 5.9+ + Speech framework (SFSpeechRecognizer), AVFoundation (AVAudioEngine), Carbon (existing), ApplicationServices (existing) (015-voice-input)
+- N/A — no audio or transcription persisted; text flows into existing ChatMessage pipeline (015-voice-input)
 
 ## Recent Changes
+- 015-voice-input: Voice-to-text input via Apple SFSpeechRecognizer with on-device recognition. Mic button in ChatInputView and PromptView. Option+D global hotkey to toggle recording. Live partial transcription streams into text field. Silence timeout (3s configurable), max duration (60s configurable). Permission handling with actionable System Settings guidance. Stops recording on app switch, Enter key, or manual toggle. Text appends to existing input (FR-012). UserDefaults-backed configuration.
 - 014-claude-code-provider: Claude Code CLI as an LLM provider. Uses persistent subprocess with bidirectional NDJSON via `--input-format stream-json` and `--output-format stream-json`. No API key needed. User messages sent as JSON on stdin (`{"type":"user","message":{"role":"user","content":"..."}}`). Process started eagerly, stays alive across multi-turn conversation. Auto-restart on crash. Model aliases (sonnet/opus/haiku). Configurable allowed tools. Graceful cleanup on app quit.
 - 013-stealth-mode: Stealth mode makes Extremis invisible during screen sharing. Uses NSWindow.sharingType=.none for screen capture exclusion, collectionBehavior for Mission Control hiding, process name disguise, menu bar icon hiding. Toggle via Option+Shift+S hotkey. Configurable in Preferences. Adjustable window opacity with material blur (text stays readable). Sound notifications auto-suppressed in stealth. Screenshot button captures screen behind Extremis panel via CGWindowListCreateImage.
 - 012-image-attachments: Image attachments for chat messages via paste, drag-and-drop, and file picker. Uses ImageIO for processing, actor-based file persistence, and inline base64 thumbnails in session JSON.

--- a/Extremis/App/AppDelegate.swift
+++ b/Extremis/App/AppDelegate.swift
@@ -475,6 +475,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         } catch {
             print("❌ Failed to register preferences hotkey: \(error)")
         }
+
+        // Voice input hotkey: Option+D (toggle voice recording)
+        let voiceInputConfig = HotkeyConfiguration(
+            keyCode: UInt32(kVK_ANSI_D),  // D key
+            modifiers: UInt32(optionKey)   // Option
+        )
+        do {
+            try hotkeyManager.register(
+                identifier: .voiceInput,
+                configuration: voiceInputConfig
+            ) { [weak self] in
+                self?.handleVoiceInputActivation()
+            }
+        } catch {
+            print("❌ Failed to register voice input hotkey: \(error)")
+        }
     }
 
     private func checkPermissions() {
@@ -578,6 +594,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 await performSummarization(text: selectedText, source: source)
             }
             // No selection → complete no-op (no logs, no processing)
+        }
+    }
+
+    /// Handle voice input hotkey (Option+D) — show prompt window if needed, then toggle recording
+    func handleVoiceInputActivation() {
+        print("🎙️ Voice input hotkey activated!")
+
+        // If prompt window is not visible, show it first (chat mode)
+        if !(promptWindowController.window?.isVisible ?? false) {
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+                await captureContextAndShowPrompt()
+                // Small delay to let the window appear before starting recording
+                try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+                VoiceInputManager.shared.toggleRecording()
+            }
+        } else {
+            VoiceInputManager.shared.toggleRecording()
         }
     }
 

--- a/Extremis/Connectors/Models/MCPTypes.swift
+++ b/Extremis/Connectors/Models/MCPTypes.swift
@@ -89,7 +89,7 @@ enum JSONRPCId: Codable, Hashable {
 // MARK: - JSON Value Type
 
 /// Generic JSON value for dynamic content
-indirect enum JSONValue: Codable, Equatable {
+indirect enum JSONValue: Codable, Equatable, Sendable {
     case null
     case bool(Bool)
     case int(Int)

--- a/Extremis/Core/Models/VoiceInputModels.swift
+++ b/Extremis/Core/Models/VoiceInputModels.swift
@@ -1,0 +1,103 @@
+// MARK: - Voice Input Models
+// Data structures for voice input state, transcription updates, and configuration
+
+import Foundation
+
+// MARK: - Voice Input State
+
+/// Represents the current state of the voice input system
+enum VoiceInputState: Equatable {
+    case idle
+    case requesting
+    case recording
+    case error(String)
+
+    var isRecording: Bool {
+        if case .recording = self { return true }
+        return false
+    }
+
+    var isIdle: Bool {
+        if case .idle = self { return true }
+        return false
+    }
+
+    var isError: Bool {
+        if case .error = self { return true }
+        return false
+    }
+
+    var errorMessage: String? {
+        if case .error(let message) = self { return message }
+        return nil
+    }
+}
+
+// MARK: - Transcription Update
+
+/// A value emitted by the speech recognition stream for each partial or final result
+struct TranscriptionUpdate: Equatable {
+    /// The current best transcription (replaces previous partial)
+    let text: String
+    /// Whether this is the final, definitive result
+    let isFinal: Bool
+    /// Optional confidence score (0.0–1.0) from recognizer
+    let confidence: Double?
+
+    init(text: String, isFinal: Bool, confidence: Double? = nil) {
+        self.text = text
+        self.isFinal = isFinal
+        self.confidence = confidence
+    }
+}
+
+// MARK: - Voice Input Configuration
+
+/// UserDefaults-backed settings for voice input behavior
+struct VoiceInputConfiguration {
+
+    // MARK: - Constants
+
+    static let defaultSilenceTimeout: Double = 3.0
+    static let defaultMaxDuration: Double = 60.0
+
+    // MARK: - Properties
+
+    /// Seconds of silence before auto-stop
+    var silenceTimeoutSeconds: Double {
+        get {
+            let val = UserDefaults.standard.double(forKey: "voiceInput.silenceTimeout")
+            return val > 0 ? val : Self.defaultSilenceTimeout
+        }
+        set { UserDefaults.standard.set(newValue, forKey: "voiceInput.silenceTimeout") }
+    }
+
+    /// Maximum recording duration in seconds
+    var maxDurationSeconds: Double {
+        get {
+            let val = UserDefaults.standard.double(forKey: "voiceInput.maxDuration")
+            return val > 0 ? val : Self.defaultMaxDuration
+        }
+        set { UserDefaults.standard.set(newValue, forKey: "voiceInput.maxDuration") }
+    }
+
+    /// Whether to show animated waveform indicator during recording
+    var showWaveformIndicator: Bool {
+        get {
+            if UserDefaults.standard.object(forKey: "voiceInput.showWaveform") == nil { return true }
+            return UserDefaults.standard.bool(forKey: "voiceInput.showWaveform")
+        }
+        set { UserDefaults.standard.set(newValue, forKey: "voiceInput.showWaveform") }
+    }
+}
+
+// MARK: - Voice Permission Status
+
+/// Combined permission status for voice input
+enum VoicePermissionStatus: Equatable {
+    case authorized
+    case microphoneDenied
+    case speechRecognitionDenied
+    case notDetermined
+    case siriDisabled
+}

--- a/Extremis/Core/Services/HotkeyManager.swift
+++ b/Extremis/Core/Services/HotkeyManager.swift
@@ -11,6 +11,7 @@ enum HotkeyIdentifier: UInt32, CaseIterable {
     case magicMode = 2     // Magic mode hotkey (Option+Tab for summarization)
     case stealthToggle = 3 // Stealth mode toggle
     case preferences = 4   // Open Preferences (when menu bar hidden)
+    case voiceInput = 5    // Voice input toggle (Option+D)
 }
 
 /// Manages global hotkey registration and handling

--- a/Extremis/Core/Services/PermissionManager.swift
+++ b/Extremis/Core/Services/PermissionManager.swift
@@ -4,6 +4,8 @@
 import Foundation
 import AppKit
 import ApplicationServices
+import AVFoundation
+import Speech
 
 /// Manages macOS permissions required by Extremis
 @MainActor
@@ -26,6 +28,26 @@ final class PermissionManager {
     /// Current accessibility permission status
     var accessibilityStatus: PermissionStatus {
         AXIsProcessTrusted() ? .granted : .denied
+    }
+
+    /// Current microphone permission status
+    var microphoneStatus: PermissionStatus {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized: return .granted
+        case .denied, .restricted: return .denied
+        case .notDetermined: return .notDetermined
+        @unknown default: return .notDetermined
+        }
+    }
+
+    /// Current speech recognition permission status
+    var speechRecognitionStatus: PermissionStatus {
+        switch SFSpeechRecognizer.authorizationStatus() {
+        case .authorized: return .granted
+        case .denied, .restricted: return .denied
+        case .notDetermined: return .notDetermined
+        @unknown default: return .notDetermined
+        }
     }
     
     // MARK: - Initialization
@@ -61,7 +83,9 @@ final class PermissionManager {
     /// - Returns: Dictionary of permission names to their status
     func checkAllPermissions() -> [String: PermissionStatus] {
         return [
-            "Accessibility": accessibilityStatus
+            "Accessibility": accessibilityStatus,
+            "Microphone": microphoneStatus,
+            "Speech Recognition": speechRecognitionStatus
         ]
     }
     
@@ -72,6 +96,20 @@ final class PermissionManager {
         }
     }
     
+    /// Open System Preferences to Microphone pane
+    func openMicrophonePreferences() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
+    /// Open System Preferences to Speech Recognition pane
+    func openSpeechRecognitionPreferences() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_SpeechRecognition") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+
     // MARK: - Permission Helpers
     
     /// Get the frontmost application

--- a/Extremis/Core/Services/SpeechRecognitionService.swift
+++ b/Extremis/Core/Services/SpeechRecognitionService.swift
@@ -1,0 +1,330 @@
+// MARK: - Speech Recognition Service
+// Wraps AVCaptureSession + SFSpeechRecognizer for on-device speech-to-text
+
+import Foundation
+import Speech
+import AVFoundation
+import CoreMedia
+import CoreAudio
+
+/// Provides on-device speech recognition via Apple's Speech framework
+@MainActor
+final class SpeechRecognitionService: NSObject, SFSpeechRecognizerDelegate {
+
+    // MARK: - Properties
+
+    private let speechRecognizer: SFSpeechRecognizer?
+    private let audioEngine = AVAudioEngine()
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var isEngineRunning = false
+
+    // AVCaptureSession-based audio capture (bypasses AVAudioEngine aggregate device bugs on macOS 26)
+    private var captureSession: AVCaptureSession?
+    private var audioCaptureDelegate: AudioCaptureDelegate?
+
+    /// Whether on-device recognition is available
+    var isAvailable: Bool {
+        speechRecognizer?.isAvailable ?? false
+    }
+
+    /// Whether on-device recognition is supported (requires Siri enabled)
+    var supportsOnDevice: Bool {
+        speechRecognizer?.supportsOnDeviceRecognition ?? false
+    }
+
+    // MARK: - Initialization
+
+    override init() {
+        self.speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+        super.init()
+        speechRecognizer?.delegate = self
+    }
+
+    // MARK: - Authorization
+
+    /// Current speech recognition authorization status
+    static var authorizationStatus: SFSpeechRecognizerAuthorizationStatus {
+        SFSpeechRecognizer.authorizationStatus()
+    }
+
+    /// Request speech recognition authorization
+    nonisolated static func requestAuthorization() async -> SFSpeechRecognizerAuthorizationStatus {
+        await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+    }
+
+    // MARK: - Transcription
+
+    /// Start transcribing speech from the microphone.
+    /// Returns an AsyncThrowingStream of TranscriptionUpdate values.
+    func startTranscription() throws -> AsyncThrowingStream<TranscriptionUpdate, Error> {
+        stopTranscription()
+
+        guard let speechRecognizer, speechRecognizer.isAvailable else {
+            throw SpeechRecognitionError.recognizerUnavailable
+        }
+
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        request.requiresOnDeviceRecognition = false
+        self.recognitionRequest = request
+
+        // AVCaptureSession is preferred (avoids AVAudioEngine aggregate device bugs on macOS 26).
+        // Falls back to AVAudioEngine if capture session setup fails.
+        let usedCaptureSession = try setupAudioCapture(request: request)
+
+        if !usedCaptureSession {
+            audioEngine.prepare()
+            try audioEngine.start()
+            isEngineRunning = true
+        }
+
+        return AsyncThrowingStream { continuation in
+            self.recognitionTask = speechRecognizer.recognitionTask(with: request) { [weak self] result, error in
+                if let result {
+                    let bestTranscription = result.bestTranscription
+                    let confidence: Double? = bestTranscription.segments.last.map { Double($0.confidence) }
+
+                    continuation.yield(TranscriptionUpdate(
+                        text: bestTranscription.formattedString,
+                        isFinal: result.isFinal,
+                        confidence: confidence
+                    ))
+
+                    if result.isFinal {
+                        continuation.finish()
+                        Task { @MainActor in self?.cleanupAudioCapture() }
+                    }
+                }
+
+                if let error {
+                    let nsError = error as NSError
+                    if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 216 {
+                        // Recognition was cancelled
+                        continuation.finish()
+                    } else if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 1110 {
+                        continuation.finish(throwing: SpeechRecognitionError.siriDisabled)
+                    } else {
+                        continuation.finish(throwing: SpeechRecognitionError.recognitionFailed(error.localizedDescription))
+                    }
+                    Task { @MainActor in self?.cleanupAudioCapture() }
+                }
+            }
+
+            continuation.onTermination = { @Sendable [weak self] _ in
+                guard let self else { return }
+                Task { @MainActor in self.stopTranscription() }
+            }
+        }
+    }
+
+    /// Stop transcription and clean up all resources
+    func stopTranscription() {
+        recognitionRequest?.endAudio()
+        recognitionRequest = nil
+
+        recognitionTask?.finish()
+        recognitionTask = nil
+
+        cleanupAudioCapture()
+    }
+
+    // MARK: - Private
+
+    /// Sets up audio capture using AVCaptureSession (preferred) or AVAudioEngine (fallback).
+    /// Returns true if AVCaptureSession is being used.
+    private func setupAudioCapture(request: SFSpeechAudioBufferRecognitionRequest) throws -> Bool {
+        // AVCaptureSession bypasses the broken aggregate device path in AVAudioEngine
+        // on macOS 26 that causes CoreAudio -10877 errors and zero buffer delivery.
+        do {
+            let session = AVCaptureSession()
+
+            guard let microphone = AVCaptureDevice.default(for: .audio) else {
+                throw SpeechRecognitionError.audioEngineFailure("No microphone")
+            }
+
+            let audioInput = try AVCaptureDeviceInput(device: microphone)
+            guard session.canAddInput(audioInput) else {
+                throw SpeechRecognitionError.audioEngineFailure("Cannot add audio input")
+            }
+            session.addInput(audioInput)
+
+            let audioOutput = AVCaptureAudioDataOutput()
+            guard session.canAddOutput(audioOutput) else {
+                throw SpeechRecognitionError.audioEngineFailure("Cannot add audio output")
+            }
+            session.addOutput(audioOutput)
+
+            let delegate = AudioCaptureDelegate(request: request)
+            let captureQueue = DispatchQueue(label: "com.extremis.audiocapture", qos: .userInteractive)
+            audioOutput.setSampleBufferDelegate(delegate, queue: captureQueue)
+
+            session.startRunning()
+
+            self.captureSession = session
+            self.audioCaptureDelegate = delegate
+            return true
+        } catch {
+            // Fall through to AVAudioEngine
+        }
+
+        // Fallback: AVAudioEngine with explicit mono format
+        let inputNode = audioEngine.inputNode
+
+        if #available(macOS 14.0, *) {
+            try? inputNode.setVoiceProcessingEnabled(true)
+        }
+
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        guard recordingFormat.sampleRate > 0 else {
+            throw SpeechRecognitionError.audioEngineFailure("No audio input available")
+        }
+
+        // Explicit mono format avoids multi-channel formats from voice processing
+        let tapFormat = AVAudioFormat(standardFormatWithSampleRate: recordingFormat.sampleRate, channels: 1)
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: tapFormat) { buffer, _ in
+            request.append(buffer)
+        }
+
+        return false
+    }
+
+    private func cleanupAudioCapture() {
+        if let session = captureSession {
+            session.stopRunning()
+            captureSession = nil
+            audioCaptureDelegate = nil
+        }
+
+        if isEngineRunning {
+            audioEngine.stop()
+            audioEngine.inputNode.removeTap(onBus: 0)
+            isEngineRunning = false
+        }
+    }
+
+    // MARK: - SFSpeechRecognizerDelegate
+
+    nonisolated func speechRecognizer(_ speechRecognizer: SFSpeechRecognizer, availabilityDidChange available: Bool) {
+        Task { @MainActor in
+            if !available {
+                self.stopTranscription()
+            }
+        }
+    }
+}
+
+// MARK: - Audio Capture Delegate
+
+/// Bridges AVCaptureSession audio output to SFSpeechAudioBufferRecognitionRequest.
+/// This bypasses AVAudioEngine entirely, avoiding the aggregate device bugs on macOS 26.
+final class AudioCaptureDelegate: NSObject, AVCaptureAudioDataOutputSampleBufferDelegate {
+    private let request: SFSpeechAudioBufferRecognitionRequest
+
+    init(request: SFSpeechAudioBufferRecognitionRequest) {
+        self.request = request
+        super.init()
+    }
+
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        guard let pcmBuffer = sampleBuffer.toAudioPCMBuffer() else { return }
+        request.append(pcmBuffer)
+    }
+}
+
+// MARK: - CMSampleBuffer → AVAudioPCMBuffer Conversion
+
+extension CMSampleBuffer {
+    /// Converts an audio CMSampleBuffer to an AVAudioPCMBuffer suitable for SFSpeechRecognitionRequest.
+    func toAudioPCMBuffer() -> AVAudioPCMBuffer? {
+        guard let formatDescription = CMSampleBufferGetFormatDescription(self),
+              let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription) else {
+            return nil
+        }
+
+        let isInterleaved = streamDescription.pointee.mFormatFlags & kAudioFormatFlagIsNonInterleaved == 0
+
+        guard let avFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: streamDescription.pointee.mSampleRate,
+            channels: AVAudioChannelCount(streamDescription.pointee.mChannelsPerFrame),
+            interleaved: isInterleaved
+        ) else {
+            return nil
+        }
+
+        let frameCount = CMSampleBufferGetNumSamples(self)
+        guard frameCount > 0,
+              let pcmBuffer = AVAudioPCMBuffer(pcmFormat: avFormat, frameCapacity: AVAudioFrameCount(frameCount)) else {
+            return nil
+        }
+        pcmBuffer.frameLength = AVAudioFrameCount(frameCount)
+
+        guard let blockBuffer = CMSampleBufferGetDataBuffer(self) else { return nil }
+
+        var totalLength: Int = 0
+        var dataPointer: UnsafeMutablePointer<Int8>?
+        let status = CMBlockBufferGetDataPointer(
+            blockBuffer, atOffset: 0,
+            lengthAtOffsetOut: nil, totalLengthOut: &totalLength,
+            dataPointerOut: &dataPointer
+        )
+        guard status == noErr, let srcData = dataPointer, totalLength > 0 else { return nil }
+
+        guard let channelData = pcmBuffer.floatChannelData else { return nil }
+
+        let channels = Int(streamDescription.pointee.mChannelsPerFrame)
+        let bytesPerFrame = Int(streamDescription.pointee.mBytesPerFrame)
+
+        if channels == 1 || !isInterleaved {
+            let bytesPerChannel = frameCount * Int(streamDescription.pointee.mBitsPerChannel / 8)
+            for ch in 0..<channels {
+                let copySize = min(bytesPerChannel, totalLength - ch * bytesPerChannel)
+                guard copySize > 0 else { continue }
+                memcpy(channelData[ch], srcData.advanced(by: ch * bytesPerChannel), copySize)
+            }
+        } else {
+            let copySize = min(totalLength, frameCount * bytesPerFrame)
+            memcpy(channelData[0], srcData, copySize)
+        }
+
+        return pcmBuffer
+    }
+}
+
+// MARK: - Speech Recognition Errors
+
+enum SpeechRecognitionError: LocalizedError, Sendable {
+    case recognizerUnavailable
+    case audioEngineFailure(String)
+    case recognitionFailed(String)
+    case microphoneAccessDenied
+    case speechRecognitionDenied
+    case siriDisabled
+
+    var errorDescription: String? {
+        switch self {
+        case .recognizerUnavailable:
+            return "Speech recognition is unavailable. Enable Dictation in System Settings → Keyboard → Dictation."
+        case .audioEngineFailure(let detail):
+            return "Audio engine error: \(detail)"
+        case .recognitionFailed(let detail):
+            return "Recognition failed: \(detail)"
+        case .microphoneAccessDenied:
+            return "Microphone access denied. Open System Settings > Privacy > Microphone to grant access."
+        case .speechRecognitionDenied:
+            return "Speech recognition denied. Open System Settings > Privacy > Speech Recognition to grant access."
+        case .siriDisabled:
+            return "Enable Dictation in System Settings → Keyboard → Dictation for voice input."
+        }
+    }
+}

--- a/Extremis/Core/Services/VoiceInputManager.swift
+++ b/Extremis/Core/Services/VoiceInputManager.swift
@@ -5,6 +5,7 @@ import Foundation
 import Speech
 import AVFoundation
 import AppKit
+import Combine
 
 /// Central coordinator for voice input functionality
 @MainActor
@@ -31,6 +32,7 @@ final class VoiceInputManager: ObservableObject {
     private var maxDurationTimer: Timer?
     private var lastPartialUpdateTime: Date?
     private var errorDismissTask: Task<Void, Never>?
+    private var stealthObserver: Any?
 
     // MARK: - Initialization
 
@@ -40,6 +42,16 @@ final class VoiceInputManager: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
+            Task { @MainActor in
+                if self?.state.isRecording == true {
+                    self?.stopRecording()
+                }
+            }
+        }
+
+        // Stop recording immediately if stealth mode is activated
+        stealthObserver = StealthManager.shared.$isStealthActive.sink { [weak self] active in
+            guard active else { return }
             Task { @MainActor in
                 if self?.state.isRecording == true {
                     self?.stopRecording()
@@ -62,6 +74,13 @@ final class VoiceInputManager: ObservableObject {
     /// Start voice recording and transcription
     func startRecording() {
         guard state.isIdle else { return }
+
+        // Block voice input in stealth mode — macOS shows a system mic indicator
+        // in the menu bar that cannot be hidden, which would compromise stealth.
+        if StealthManager.shared.isStealthActive {
+            setError("Voice input is disabled in stealth mode (mic indicator visible in menu bar).")
+            return
+        }
 
         Task {
             let permissionStatus = await checkPermissions()

--- a/Extremis/Core/Services/VoiceInputManager.swift
+++ b/Extremis/Core/Services/VoiceInputManager.swift
@@ -1,0 +1,257 @@
+// MARK: - Voice Input Manager
+// Coordinates voice recording, transcription, and state management
+
+import Foundation
+import Speech
+import AVFoundation
+import AppKit
+
+/// Central coordinator for voice input functionality
+@MainActor
+final class VoiceInputManager: ObservableObject {
+
+    // MARK: - Singleton
+
+    static let shared = VoiceInputManager()
+
+    // MARK: - Published Properties
+
+    /// Current state of the voice input system
+    @Published private(set) var state: VoiceInputState = .idle
+
+    /// Live partial transcription text (updated in real-time while recording)
+    @Published private(set) var partialTranscription: String = ""
+
+    // MARK: - Private Properties
+
+    private let speechService = SpeechRecognitionService()
+    private var configuration = VoiceInputConfiguration()
+    private var transcriptionTask: Task<Void, Never>?
+    private var silenceTimer: Timer?
+    private var maxDurationTimer: Timer?
+    private var lastPartialUpdateTime: Date?
+    private var errorDismissTask: Task<Void, Never>?
+
+    // MARK: - Initialization
+
+    private init() {
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didResignActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                if self?.state.isRecording == true {
+                    self?.stopRecording()
+                }
+            }
+        }
+    }
+
+    // MARK: - Public Methods
+
+    /// Toggle recording on/off
+    func toggleRecording() {
+        if state.isRecording {
+            stopRecording()
+        } else if state.isIdle {
+            startRecording()
+        }
+    }
+
+    /// Start voice recording and transcription
+    func startRecording() {
+        guard state.isIdle else { return }
+
+        Task {
+            let permissionStatus = await checkPermissions()
+            switch permissionStatus {
+            case .authorized:
+                beginTranscription()
+            case .notDetermined:
+                state = .requesting
+                let granted = await requestPermissions()
+                if granted {
+                    beginTranscription()
+                } else {
+                    if Bundle.main.object(forInfoDictionaryKey: "NSMicrophoneUsageDescription") == nil {
+                        setError("Voice input requires running Extremis as an app bundle. Use the built .app or scripts/build.sh.")
+                    } else {
+                        setError("Microphone or speech recognition permission was denied.")
+                    }
+                }
+            case .microphoneDenied:
+                setError("Microphone access denied. Open System Settings > Privacy & Security > Microphone.")
+            case .speechRecognitionDenied:
+                setError("Speech recognition denied. Open System Settings > Privacy & Security > Speech Recognition.")
+            case .siriDisabled:
+                setError("Enable Dictation in System Settings → Keyboard → Dictation for voice input.")
+            }
+        }
+    }
+
+    /// Stop recording and finalize transcription
+    func stopRecording() {
+        guard state.isRecording else { return }
+
+        invalidateTimers()
+        speechService.stopTranscription()
+        transcriptionTask?.cancel()
+        transcriptionTask = nil
+
+        state = .idle
+    }
+
+    /// Get the current transcription and reset for next session
+    func consumeTranscription() -> String {
+        let text = partialTranscription
+        partialTranscription = ""
+        return text
+    }
+
+    // MARK: - Permission Checking
+
+    /// Check combined voice input permission status
+    func checkPermissions() async -> VoicePermissionStatus {
+        let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+        switch micStatus {
+        case .denied, .restricted:
+            return .microphoneDenied
+        case .notDetermined:
+            return .notDetermined
+        case .authorized:
+            break
+        @unknown default:
+            return .notDetermined
+        }
+
+        let speechStatus = SpeechRecognitionService.authorizationStatus
+        switch speechStatus {
+        case .denied, .restricted:
+            return .speechRecognitionDenied
+        case .notDetermined:
+            return .notDetermined
+        case .authorized:
+            break
+        @unknown default:
+            return .notDetermined
+        }
+
+        if !speechService.supportsOnDevice && !speechService.isAvailable {
+            return .siriDisabled
+        }
+
+        return .authorized
+    }
+
+    /// Request all required permissions.
+    func requestPermissions() async -> Bool {
+        guard Bundle.main.object(forInfoDictionaryKey: "NSMicrophoneUsageDescription") != nil else {
+            return false
+        }
+        guard Bundle.main.object(forInfoDictionaryKey: "NSSpeechRecognitionUsageDescription") != nil else {
+            return false
+        }
+
+        let micGranted = await AVCaptureDevice.requestAccess(for: .audio)
+        guard micGranted else { return false }
+
+        let speechStatus = await SpeechRecognitionService.requestAuthorization()
+        return speechStatus == .authorized
+    }
+
+    // MARK: - Private Methods
+
+    private func beginTranscription() {
+        do {
+            let stream = try speechService.startTranscription()
+            state = .recording
+            lastPartialUpdateTime = Date()
+            startTimers()
+
+            transcriptionTask = Task { [weak self] in
+                do {
+                    for try await update in stream {
+                        guard !Task.isCancelled else { break }
+                        await MainActor.run {
+                            self?.handleTranscriptionUpdate(update)
+                        }
+                    }
+                } catch {
+                    guard !Task.isCancelled else { return }
+                    await MainActor.run {
+                        self?.handleTranscriptionError(error)
+                    }
+                }
+            }
+        } catch {
+            setError(error.localizedDescription)
+        }
+    }
+
+    private func handleTranscriptionUpdate(_ update: TranscriptionUpdate) {
+        partialTranscription = update.text
+        lastPartialUpdateTime = Date()
+
+        resetSilenceTimer()
+
+        if update.isFinal {
+            invalidateTimers()
+            state = .idle
+        }
+    }
+
+    private func handleTranscriptionError(_ error: Error) {
+        invalidateTimers()
+        setError(error.localizedDescription)
+    }
+
+    private func setError(_ message: String) {
+        state = .error(message)
+
+        errorDismissTask?.cancel()
+        errorDismissTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                if self?.state.isError == true {
+                    self?.state = .idle
+                }
+            }
+        }
+    }
+
+    // MARK: - Timer Management
+
+    private func startTimers() {
+        resetSilenceTimer()
+
+        maxDurationTimer = Timer.scheduledTimer(
+            withTimeInterval: configuration.maxDurationSeconds,
+            repeats: false
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.stopRecording()
+            }
+        }
+    }
+
+    private func resetSilenceTimer() {
+        silenceTimer?.invalidate()
+        silenceTimer = Timer.scheduledTimer(
+            withTimeInterval: configuration.silenceTimeoutSeconds,
+            repeats: false
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.stopRecording()
+            }
+        }
+    }
+
+    private func invalidateTimers() {
+        silenceTimer?.invalidate()
+        silenceTimer = nil
+        maxDurationTimer?.invalidate()
+        maxDurationTimer = nil
+    }
+}

--- a/Extremis/Info.plist
+++ b/Extremis/Info.plist
@@ -52,6 +52,14 @@
     <key>NSSupportsAutomaticGraphicsSwitching</key>
     <true/>
 
+    <!-- Microphone Permission - Required for voice input transcription -->
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Extremis uses your microphone to transcribe voice input into text prompts.</string>
+
+    <!-- Speech Recognition Permission - Required for on-device speech-to-text -->
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Extremis uses on-device speech recognition to convert your voice to text.</string>
+
     <!-- App Transport Security - Allow localhost HTTP for Ollama -->
     <key>NSAppTransportSecurity</key>
     <dict>

--- a/Extremis/Package.swift
+++ b/Extremis/Package.swift
@@ -50,7 +50,9 @@ let package = Package(
             ],
             linkerSettings: [
                 .linkedFramework("Carbon"),
-                .linkedFramework("ApplicationServices")
+                .linkedFramework("ApplicationServices"),
+                .linkedFramework("Speech"),
+                .linkedFramework("AVFoundation")
             ]
         )
     ]

--- a/Extremis/Tests/Core/SpeechRecognitionServiceTests.swift
+++ b/Extremis/Tests/Core/SpeechRecognitionServiceTests.swift
@@ -1,0 +1,512 @@
+// MARK: - Speech Recognition Service Unit Tests
+// Tests for AudioCaptureDelegate, CMSampleBuffer conversion, and error classification
+
+import Foundation
+import AVFoundation
+import CoreMedia
+import CoreAudio
+
+// MARK: - Test Runner Framework
+
+struct TestRunner {
+    static var passedCount = 0
+    static var failedCount = 0
+    static var failedTests: [(name: String, message: String)] = []
+    static var currentGroup = ""
+
+    static func reset() {
+        passedCount = 0
+        failedCount = 0
+        failedTests = []
+        currentGroup = ""
+    }
+
+    static func suite(_ name: String) {
+        currentGroup = name
+        print("")
+        print("📦 \(name)")
+        print("----------------------------------------")
+    }
+
+    static func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ testName: String) {
+        if actual == expected {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            let message = "Expected '\(expected)' but got '\(actual)'"
+            failedTests.append((testName, message))
+            print("  ✗ \(testName): \(message)")
+        }
+    }
+
+    static func assertTrue(_ condition: Bool, _ testName: String) {
+        if condition {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected true but got false"))
+            print("  ✗ \(testName): Expected true but got false")
+        }
+    }
+
+    static func assertFalse(_ condition: Bool, _ testName: String) {
+        assertTrue(!condition, testName)
+    }
+
+    static func assertNil<T>(_ value: T?, _ testName: String) {
+        if value == nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected nil but got value"))
+            print("  ✗ \(testName): Expected nil but got value")
+        }
+    }
+
+    static func assertNotNil<T>(_ value: T?, _ testName: String) {
+        if value != nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected non-nil but got nil"))
+            print("  ✗ \(testName): Expected non-nil but got nil")
+        }
+    }
+
+    static func printSummary() {
+        print("")
+        print("==================================================")
+        print("TEST SUMMARY")
+        print("==================================================")
+        print("Passed: \(passedCount)")
+        print("Failed: \(failedCount)")
+        print("Total:  \(passedCount + failedCount)")
+        if !failedTests.isEmpty {
+            print("")
+            print("Failed tests:")
+            for (name, message) in failedTests {
+                print("  - \(name): \(message)")
+            }
+        }
+        print("==================================================")
+    }
+}
+
+// MARK: - Embedded CMSampleBuffer Extension (mirrors main module for standalone testing)
+
+extension CMSampleBuffer {
+    func toAudioPCMBuffer() -> AVAudioPCMBuffer? {
+        guard let formatDescription = CMSampleBufferGetFormatDescription(self),
+              let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(formatDescription) else {
+            return nil
+        }
+
+        let isInterleaved = streamDescription.pointee.mFormatFlags & kAudioFormatFlagIsNonInterleaved == 0
+
+        guard let avFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: streamDescription.pointee.mSampleRate,
+            channels: AVAudioChannelCount(streamDescription.pointee.mChannelsPerFrame),
+            interleaved: isInterleaved
+        ) else {
+            return nil
+        }
+
+        let frameCount = CMSampleBufferGetNumSamples(self)
+        guard frameCount > 0,
+              let pcmBuffer = AVAudioPCMBuffer(pcmFormat: avFormat, frameCapacity: AVAudioFrameCount(frameCount)) else {
+            return nil
+        }
+        pcmBuffer.frameLength = AVAudioFrameCount(frameCount)
+
+        guard let blockBuffer = CMSampleBufferGetDataBuffer(self) else { return nil }
+
+        var totalLength: Int = 0
+        var dataPointer: UnsafeMutablePointer<Int8>?
+        let status = CMBlockBufferGetDataPointer(
+            blockBuffer, atOffset: 0,
+            lengthAtOffsetOut: nil, totalLengthOut: &totalLength,
+            dataPointerOut: &dataPointer
+        )
+        guard status == noErr, let srcData = dataPointer, totalLength > 0 else { return nil }
+
+        guard let channelData = pcmBuffer.floatChannelData else { return nil }
+
+        let channels = Int(streamDescription.pointee.mChannelsPerFrame)
+        let bytesPerFrame = Int(streamDescription.pointee.mBytesPerFrame)
+
+        if channels == 1 || !isInterleaved {
+            let bytesPerChannel = frameCount * Int(streamDescription.pointee.mBitsPerChannel / 8)
+            for ch in 0..<channels {
+                let copySize = min(bytesPerChannel, totalLength - ch * bytesPerChannel)
+                guard copySize > 0 else { continue }
+                memcpy(channelData[ch], srcData.advanced(by: ch * bytesPerChannel), copySize)
+            }
+        } else {
+            let copySize = min(totalLength, frameCount * bytesPerFrame)
+            memcpy(channelData[0], srcData, copySize)
+        }
+
+        return pcmBuffer
+    }
+}
+
+// MARK: - Test Helpers
+
+/// Creates a CMSampleBuffer with audio data for testing
+func createTestAudioSampleBuffer(
+    sampleRate: Float64 = 48000,
+    channels: UInt32 = 1,
+    frameCount: Int = 1024,
+    interleaved: Bool = true
+) -> CMSampleBuffer? {
+    let bytesPerSample: UInt32 = 4 // Float32
+    let bytesPerFrame = bytesPerSample * channels
+    let totalBytes = frameCount * Int(bytesPerFrame)
+
+    // Create audio format description
+    var asbd = AudioStreamBasicDescription(
+        mSampleRate: sampleRate,
+        mFormatID: kAudioFormatLinearPCM,
+        mFormatFlags: kAudioFormatFlagIsFloat | (interleaved ? 0 : kAudioFormatFlagIsNonInterleaved),
+        mBytesPerPacket: bytesPerFrame,
+        mFramesPerPacket: 1,
+        mBytesPerFrame: bytesPerFrame,
+        mChannelsPerFrame: channels,
+        mBitsPerChannel: bytesPerSample * 8,
+        mReserved: 0
+    )
+
+    var formatDescription: CMAudioFormatDescription?
+    let formatStatus = CMAudioFormatDescriptionCreate(
+        allocator: kCFAllocatorDefault,
+        asbd: &asbd,
+        layoutSize: 0,
+        layout: nil,
+        magicCookieSize: 0,
+        magicCookie: nil,
+        extensions: nil,
+        formatDescriptionOut: &formatDescription
+    )
+    guard formatStatus == noErr, let formatDesc = formatDescription else { return nil }
+
+    // Allocate memory and fill with sine wave data
+    let memory = UnsafeMutablePointer<Int8>.allocate(capacity: totalBytes)
+    let floatPtr = UnsafeMutableRawPointer(memory).bindMemory(to: Float32.self, capacity: frameCount * Int(channels))
+    for i in 0..<(frameCount * Int(channels)) {
+        floatPtr[i] = sin(Float32(i) * 0.1) * 0.5
+    }
+
+    // Create block buffer backed by the allocated memory
+    var blockBuffer: CMBlockBuffer?
+    let blockStatus = CMBlockBufferCreateWithMemoryBlock(
+        allocator: kCFAllocatorDefault,
+        memoryBlock: memory,
+        blockLength: totalBytes,
+        blockAllocator: kCFAllocatorDefault,
+        customBlockSource: nil,
+        offsetToData: 0,
+        dataLength: totalBytes,
+        flags: 0,
+        blockBufferOut: &blockBuffer
+    )
+    guard blockStatus == noErr, let block = blockBuffer else {
+        memory.deallocate()
+        return nil
+    }
+
+    // Create sample buffer
+    var sampleBuffer: CMSampleBuffer?
+    let sampleStatus = CMAudioSampleBufferCreateReadyWithPacketDescriptions(
+        allocator: kCFAllocatorDefault,
+        dataBuffer: block,
+        formatDescription: formatDesc,
+        sampleCount: frameCount,
+        presentationTimeStamp: CMTime(value: 0, timescale: CMTimeScale(sampleRate)),
+        packetDescriptions: nil,
+        sampleBufferOut: &sampleBuffer
+    )
+    guard sampleStatus == noErr else { return nil }
+
+    return sampleBuffer
+}
+
+// MARK: - CMSampleBuffer → AVAudioPCMBuffer Conversion Tests
+
+func testMonoConversion() {
+    TestRunner.suite("CMSampleBuffer → PCMBuffer: Mono")
+
+    guard let sampleBuffer = createTestAudioSampleBuffer(sampleRate: 48000, channels: 1, frameCount: 1024) else {
+        TestRunner.assertTrue(false, "Failed to create test sample buffer")
+        return
+    }
+
+    let pcmBuffer = sampleBuffer.toAudioPCMBuffer()
+    TestRunner.assertNotNil(pcmBuffer, "mono conversion succeeds")
+
+    if let buf = pcmBuffer {
+        TestRunner.assertEqual(Int(buf.frameLength), 1024, "frame count matches")
+        TestRunner.assertEqual(buf.format.sampleRate, 48000, "sample rate matches")
+        TestRunner.assertEqual(Int(buf.format.channelCount), 1, "channel count is 1")
+        TestRunner.assertNotNil(buf.floatChannelData, "has float channel data")
+    }
+}
+
+func testStereoConversion() {
+    TestRunner.suite("CMSampleBuffer → PCMBuffer: Stereo")
+
+    guard let sampleBuffer = createTestAudioSampleBuffer(sampleRate: 44100, channels: 2, frameCount: 512) else {
+        TestRunner.assertTrue(false, "Failed to create stereo sample buffer")
+        return
+    }
+
+    let pcmBuffer = sampleBuffer.toAudioPCMBuffer()
+    TestRunner.assertNotNil(pcmBuffer, "stereo conversion succeeds")
+
+    if let buf = pcmBuffer {
+        TestRunner.assertEqual(Int(buf.frameLength), 512, "frame count matches")
+        TestRunner.assertEqual(buf.format.sampleRate, 44100, "sample rate matches")
+        TestRunner.assertEqual(Int(buf.format.channelCount), 2, "channel count is 2")
+    }
+}
+
+func testDifferentSampleRates() {
+    TestRunner.suite("CMSampleBuffer → PCMBuffer: Sample Rates")
+
+    let sampleRates: [Float64] = [8000, 16000, 22050, 44100, 48000, 96000]
+    for rate in sampleRates {
+        guard let sampleBuffer = createTestAudioSampleBuffer(sampleRate: rate, channels: 1, frameCount: 256) else {
+            TestRunner.assertTrue(false, "Failed to create buffer at \(rate)Hz")
+            continue
+        }
+
+        let pcmBuffer = sampleBuffer.toAudioPCMBuffer()
+        TestRunner.assertNotNil(pcmBuffer, "conversion at \(rate)Hz succeeds")
+
+        if let buf = pcmBuffer {
+            TestRunner.assertEqual(buf.format.sampleRate, rate, "sample rate \(rate) preserved")
+        }
+    }
+}
+
+func testSmallFrameCount() {
+    TestRunner.suite("CMSampleBuffer → PCMBuffer: Small Frames")
+
+    guard let sampleBuffer = createTestAudioSampleBuffer(sampleRate: 48000, channels: 1, frameCount: 1) else {
+        TestRunner.assertTrue(false, "Failed to create 1-frame buffer")
+        return
+    }
+
+    let pcmBuffer = sampleBuffer.toAudioPCMBuffer()
+    TestRunner.assertNotNil(pcmBuffer, "1-frame conversion succeeds")
+
+    if let buf = pcmBuffer {
+        TestRunner.assertEqual(Int(buf.frameLength), 1, "frame count is 1")
+    }
+}
+
+func testLargeFrameCount() {
+    TestRunner.suite("CMSampleBuffer → PCMBuffer: Large Frames")
+
+    guard let sampleBuffer = createTestAudioSampleBuffer(sampleRate: 48000, channels: 1, frameCount: 48000) else {
+        TestRunner.assertTrue(false, "Failed to create large buffer")
+        return
+    }
+
+    let pcmBuffer = sampleBuffer.toAudioPCMBuffer()
+    TestRunner.assertNotNil(pcmBuffer, "large frame conversion succeeds")
+
+    if let buf = pcmBuffer {
+        TestRunner.assertEqual(Int(buf.frameLength), 48000, "large frame count matches")
+    }
+}
+
+func testDataIntegrity() {
+    TestRunner.suite("CMSampleBuffer → PCMBuffer: Data Integrity")
+
+    guard let sampleBuffer = createTestAudioSampleBuffer(sampleRate: 48000, channels: 1, frameCount: 256) else {
+        TestRunner.assertTrue(false, "Failed to create buffer for data integrity test")
+        return
+    }
+
+    let pcmBuffer = sampleBuffer.toAudioPCMBuffer()
+    TestRunner.assertNotNil(pcmBuffer, "conversion succeeds")
+
+    if let buf = pcmBuffer, let channelData = buf.floatChannelData {
+        // Verify first sample matches our sine wave generation
+        let firstSample = channelData[0][0]
+        let expectedFirstSample = sin(Float32(0) * 0.1) * 0.5
+        TestRunner.assertEqual(firstSample, expectedFirstSample, "first sample matches source data")
+
+        // Verify a mid-buffer sample
+        let midSample = channelData[0][128]
+        let expectedMidSample = sin(Float32(128) * 0.1) * 0.5
+        TestRunner.assertEqual(midSample, expectedMidSample, "mid-buffer sample matches source data")
+
+        // Verify not all zeros
+        var hasNonZero = false
+        for i in 0..<Int(buf.frameLength) {
+            if channelData[0][i] != 0 {
+                hasNonZero = true
+                break
+            }
+        }
+        TestRunner.assertTrue(hasNonZero, "buffer contains non-zero audio data")
+    }
+}
+
+func testMultiChannelConversion() {
+    TestRunner.suite("CMSampleBuffer → PCMBuffer: Multi-Channel")
+
+    // Mono and stereo work with interleaved format (standard microphone configurations)
+    for channels: UInt32 in [1, 2] {
+        guard let sampleBuffer = createTestAudioSampleBuffer(
+            sampleRate: 48000, channels: channels, frameCount: 128, interleaved: true
+        ) else {
+            TestRunner.assertTrue(false, "Failed to create \(channels)-channel buffer")
+            continue
+        }
+
+        let pcmBuffer = sampleBuffer.toAudioPCMBuffer()
+        TestRunner.assertNotNil(pcmBuffer, "\(channels)-channel conversion succeeds")
+
+        if let buf = pcmBuffer {
+            TestRunner.assertEqual(Int(buf.format.channelCount), Int(channels), "\(channels)-channel count preserved")
+        }
+    }
+
+    // Stereo non-interleaved
+    guard let stereoNI = createTestAudioSampleBuffer(
+        sampleRate: 48000, channels: 2, frameCount: 128, interleaved: false
+    ) else {
+        TestRunner.assertTrue(false, "Failed to create stereo non-interleaved buffer")
+        return
+    }
+    let stereoNIBuf = stereoNI.toAudioPCMBuffer()
+    TestRunner.assertNotNil(stereoNIBuf, "stereo non-interleaved conversion succeeds")
+}
+
+// MARK: - SpeechRecognitionError Classification Tests
+
+// Embedded error type for standalone testing
+enum SpeechRecognitionError: LocalizedError {
+    case recognizerUnavailable
+    case audioEngineFailure(String)
+    case recognitionFailed(String)
+    case microphoneAccessDenied
+    case speechRecognitionDenied
+    case siriDisabled
+
+    var errorDescription: String? {
+        switch self {
+        case .recognizerUnavailable:
+            return "Speech recognition is unavailable. Enable Dictation in System Settings → Keyboard → Dictation."
+        case .audioEngineFailure(let detail):
+            return "Audio engine error: \(detail)"
+        case .recognitionFailed(let detail):
+            return "Recognition failed: \(detail)"
+        case .microphoneAccessDenied:
+            return "Microphone access denied. Open System Settings > Privacy > Microphone to grant access."
+        case .speechRecognitionDenied:
+            return "Speech recognition denied. Open System Settings > Privacy > Speech Recognition to grant access."
+        case .siriDisabled:
+            return "Enable Dictation in System Settings → Keyboard → Dictation for voice input."
+        }
+    }
+}
+
+/// Classifies kAFAssistantErrorDomain errors the same way SpeechRecognitionService does
+func classifyRecognitionError(domain: String, code: Int, description: String) -> SpeechRecognitionError? {
+    if domain == "kAFAssistantErrorDomain" && code == 216 {
+        return nil // Cancellation — not an error
+    } else if domain == "kAFAssistantErrorDomain" && code == 1110 {
+        return .siriDisabled
+    } else {
+        return .recognitionFailed(description)
+    }
+}
+
+func testErrorClassification() {
+    TestRunner.suite("Recognition Error Classification")
+
+    // Code 216 = cancellation, should return nil (not an error)
+    let cancelled = classifyRecognitionError(domain: "kAFAssistantErrorDomain", code: 216, description: "cancelled")
+    TestRunner.assertNil(cancelled, "code 216 is treated as cancellation (nil)")
+
+    // Code 1110 = Siri/Dictation disabled
+    let siriOff = classifyRecognitionError(domain: "kAFAssistantErrorDomain", code: 1110, description: "not enabled")
+    TestRunner.assertNotNil(siriOff, "code 1110 returns an error")
+    if let err = siriOff {
+        if case .siriDisabled = err {
+            TestRunner.assertTrue(true, "code 1110 maps to siriDisabled")
+        } else {
+            TestRunner.assertTrue(false, "code 1110 should map to siriDisabled")
+        }
+    }
+
+    // Other codes = generic recognition failure
+    let otherError = classifyRecognitionError(domain: "kAFAssistantErrorDomain", code: 999, description: "Unknown error")
+    TestRunner.assertNotNil(otherError, "other codes return an error")
+    if let err = otherError {
+        if case .recognitionFailed(let desc) = err {
+            TestRunner.assertEqual(desc, "Unknown error", "description preserved in recognitionFailed")
+        } else {
+            TestRunner.assertTrue(false, "other codes should map to recognitionFailed")
+        }
+    }
+
+    // Non-kAFAssistant domain
+    let otherDomain = classifyRecognitionError(domain: "NSCocoaErrorDomain", code: 216, description: "different domain")
+    TestRunner.assertNotNil(otherDomain, "different domain returns error even with code 216")
+}
+
+func testErrorDescriptionsAreUserFriendly() {
+    TestRunner.suite("Error Descriptions Are User-Friendly")
+
+    let errors: [SpeechRecognitionError] = [
+        .recognizerUnavailable,
+        .audioEngineFailure("test detail"),
+        .recognitionFailed("test detail"),
+        .microphoneAccessDenied,
+        .speechRecognitionDenied,
+        .siriDisabled
+    ]
+
+    for error in errors {
+        let desc = error.errorDescription ?? ""
+        TestRunner.assertFalse(desc.isEmpty, "\(error) has non-empty description")
+        // Descriptions should not contain code-level details
+        TestRunner.assertFalse(desc.contains("kAFAssistant"), "\(error) description doesn't expose internal domain")
+        TestRunner.assertFalse(desc.contains("NSError"), "\(error) description doesn't expose NSError")
+    }
+}
+
+// MARK: - Entry Point
+
+@main
+struct SpeechRecognitionServiceTests {
+    static func main() {
+        print("🧪 Speech Recognition Service Tests")
+        print("==================================================")
+
+        // CMSampleBuffer conversion tests
+        testMonoConversion()
+        testStereoConversion()
+        testDifferentSampleRates()
+        testSmallFrameCount()
+        testLargeFrameCount()
+        testDataIntegrity()
+        testMultiChannelConversion()
+
+        // Error classification tests
+        testErrorClassification()
+        testErrorDescriptionsAreUserFriendly()
+
+        TestRunner.printSummary()
+        if TestRunner.failedCount > 0 { exit(1) }
+    }
+}

--- a/Extremis/Tests/Core/VoiceInputModelsTests.swift
+++ b/Extremis/Tests/Core/VoiceInputModelsTests.swift
@@ -1,0 +1,511 @@
+// MARK: - Voice Input Models Unit Tests
+// Tests for VoiceInputState, TranscriptionUpdate, VoiceInputConfiguration, and SpeechRecognitionError
+
+import Foundation
+
+// MARK: - Test Runner Framework
+
+struct TestRunner {
+    static var passedCount = 0
+    static var failedCount = 0
+    static var failedTests: [(name: String, message: String)] = []
+    static var currentGroup = ""
+
+    static func reset() {
+        passedCount = 0
+        failedCount = 0
+        failedTests = []
+        currentGroup = ""
+    }
+
+    static func suite(_ name: String) {
+        currentGroup = name
+        print("")
+        print("📦 \(name)")
+        print("----------------------------------------")
+    }
+
+    static func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ testName: String) {
+        if actual == expected {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            let message = "Expected '\(expected)' but got '\(actual)'"
+            failedTests.append((testName, message))
+            print("  ✗ \(testName): \(message)")
+        }
+    }
+
+    static func assertTrue(_ condition: Bool, _ testName: String) {
+        if condition {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected true but got false"))
+            print("  ✗ \(testName): Expected true but got false")
+        }
+    }
+
+    static func assertFalse(_ condition: Bool, _ testName: String) {
+        assertTrue(!condition, testName)
+    }
+
+    static func assertNil<T>(_ value: T?, _ testName: String) {
+        if value == nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected nil but got value"))
+            print("  ✗ \(testName): Expected nil but got value")
+        }
+    }
+
+    static func assertNotNil<T>(_ value: T?, _ testName: String) {
+        if value != nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected non-nil but got nil"))
+            print("  ✗ \(testName): Expected non-nil but got nil")
+        }
+    }
+
+    static func printSummary() {
+        print("")
+        print("==================================================")
+        print("TEST SUMMARY")
+        print("==================================================")
+        print("Passed: \(passedCount)")
+        print("Failed: \(failedCount)")
+        print("Total:  \(passedCount + failedCount)")
+        if !failedTests.isEmpty {
+            print("")
+            print("Failed tests:")
+            for (name, message) in failedTests {
+                print("  - \(name): \(message)")
+            }
+        }
+        print("==================================================")
+    }
+}
+
+// MARK: - Embedded Type Definitions (standalone test — cannot import main module)
+
+enum VoiceInputState: Equatable {
+    case idle
+    case requesting
+    case recording
+    case error(String)
+
+    var isRecording: Bool {
+        if case .recording = self { return true }
+        return false
+    }
+
+    var isIdle: Bool {
+        if case .idle = self { return true }
+        return false
+    }
+
+    var isError: Bool {
+        if case .error = self { return true }
+        return false
+    }
+
+    var errorMessage: String? {
+        if case .error(let message) = self { return message }
+        return nil
+    }
+}
+
+struct TranscriptionUpdate: Equatable {
+    let text: String
+    let isFinal: Bool
+    let confidence: Double?
+
+    init(text: String, isFinal: Bool, confidence: Double? = nil) {
+        self.text = text
+        self.isFinal = isFinal
+        self.confidence = confidence
+    }
+}
+
+struct VoiceInputConfiguration {
+    static let defaultSilenceTimeout: Double = 3.0
+    static let defaultMaxDuration: Double = 60.0
+
+    var silenceTimeoutSeconds: Double {
+        get {
+            let val = UserDefaults.standard.double(forKey: "voiceInput.silenceTimeout")
+            return val > 0 ? val : Self.defaultSilenceTimeout
+        }
+        set { UserDefaults.standard.set(newValue, forKey: "voiceInput.silenceTimeout") }
+    }
+
+    var maxDurationSeconds: Double {
+        get {
+            let val = UserDefaults.standard.double(forKey: "voiceInput.maxDuration")
+            return val > 0 ? val : Self.defaultMaxDuration
+        }
+        set { UserDefaults.standard.set(newValue, forKey: "voiceInput.maxDuration") }
+    }
+
+    var showWaveformIndicator: Bool {
+        get {
+            if UserDefaults.standard.object(forKey: "voiceInput.showWaveform") == nil { return true }
+            return UserDefaults.standard.bool(forKey: "voiceInput.showWaveform")
+        }
+        set { UserDefaults.standard.set(newValue, forKey: "voiceInput.showWaveform") }
+    }
+}
+
+enum VoicePermissionStatus: Equatable {
+    case authorized
+    case microphoneDenied
+    case speechRecognitionDenied
+    case notDetermined
+    case siriDisabled
+}
+
+enum SpeechRecognitionError: LocalizedError {
+    case recognizerUnavailable
+    case audioEngineFailure(String)
+    case recognitionFailed(String)
+    case microphoneAccessDenied
+    case speechRecognitionDenied
+    case siriDisabled
+
+    var errorDescription: String? {
+        switch self {
+        case .recognizerUnavailable:
+            return "Speech recognition is unavailable. Enable Dictation in System Settings → Keyboard → Dictation."
+        case .audioEngineFailure(let detail):
+            return "Audio engine error: \(detail)"
+        case .recognitionFailed(let detail):
+            return "Recognition failed: \(detail)"
+        case .microphoneAccessDenied:
+            return "Microphone access denied. Open System Settings > Privacy > Microphone to grant access."
+        case .speechRecognitionDenied:
+            return "Speech recognition denied. Open System Settings > Privacy > Speech Recognition to grant access."
+        case .siriDisabled:
+            return "Enable Dictation in System Settings → Keyboard → Dictation for voice input."
+        }
+    }
+}
+
+// MARK: - VoiceInputState Tests
+
+func testVoiceInputStateProperties() {
+    TestRunner.suite("VoiceInputState Properties")
+
+    // idle
+    let idle = VoiceInputState.idle
+    TestRunner.assertTrue(idle.isIdle, "idle state isIdle")
+    TestRunner.assertFalse(idle.isRecording, "idle state is not recording")
+    TestRunner.assertFalse(idle.isError, "idle state is not error")
+    TestRunner.assertNil(idle.errorMessage, "idle state has no error message")
+
+    // recording
+    let recording = VoiceInputState.recording
+    TestRunner.assertTrue(recording.isRecording, "recording state isRecording")
+    TestRunner.assertFalse(recording.isIdle, "recording state is not idle")
+    TestRunner.assertFalse(recording.isError, "recording state is not error")
+    TestRunner.assertNil(recording.errorMessage, "recording state has no error message")
+
+    // requesting
+    let requesting = VoiceInputState.requesting
+    TestRunner.assertFalse(requesting.isIdle, "requesting state is not idle")
+    TestRunner.assertFalse(requesting.isRecording, "requesting state is not recording")
+    TestRunner.assertFalse(requesting.isError, "requesting state is not error")
+
+    // error
+    let error = VoiceInputState.error("Test error")
+    TestRunner.assertTrue(error.isError, "error state isError")
+    TestRunner.assertFalse(error.isIdle, "error state is not idle")
+    TestRunner.assertFalse(error.isRecording, "error state is not recording")
+    TestRunner.assertEqual(error.errorMessage, "Test error", "error message matches")
+}
+
+func testVoiceInputStateEquality() {
+    TestRunner.suite("VoiceInputState Equality")
+
+    TestRunner.assertTrue(VoiceInputState.idle == VoiceInputState.idle, "idle equals idle")
+    TestRunner.assertTrue(VoiceInputState.recording == VoiceInputState.recording, "recording equals recording")
+    TestRunner.assertTrue(VoiceInputState.requesting == VoiceInputState.requesting, "requesting equals requesting")
+    TestRunner.assertTrue(
+        VoiceInputState.error("msg") == VoiceInputState.error("msg"),
+        "error with same message equals"
+    )
+    TestRunner.assertFalse(
+        VoiceInputState.error("a") == VoiceInputState.error("b"),
+        "error with different messages not equal"
+    )
+    TestRunner.assertFalse(VoiceInputState.idle == VoiceInputState.recording, "idle not equal to recording")
+    TestRunner.assertFalse(VoiceInputState.recording == VoiceInputState.error("x"), "recording not equal to error")
+}
+
+// MARK: - TranscriptionUpdate Tests
+
+func testTranscriptionUpdate() {
+    TestRunner.suite("TranscriptionUpdate")
+
+    let partial = TranscriptionUpdate(text: "Hello", isFinal: false)
+    TestRunner.assertEqual(partial.text, "Hello", "partial text matches")
+    TestRunner.assertFalse(partial.isFinal, "partial is not final")
+    TestRunner.assertNil(partial.confidence, "partial has no confidence by default")
+
+    let final = TranscriptionUpdate(text: "Hello world", isFinal: true, confidence: 0.95)
+    TestRunner.assertEqual(final.text, "Hello world", "final text matches")
+    TestRunner.assertTrue(final.isFinal, "final is final")
+    TestRunner.assertNotNil(final.confidence, "final has confidence")
+    TestRunner.assertEqual(final.confidence, 0.95, "final confidence matches")
+}
+
+func testTranscriptionUpdateEquality() {
+    TestRunner.suite("TranscriptionUpdate Equality")
+
+    let a = TranscriptionUpdate(text: "Hello", isFinal: false)
+    let b = TranscriptionUpdate(text: "Hello", isFinal: false)
+    let c = TranscriptionUpdate(text: "World", isFinal: false)
+    let d = TranscriptionUpdate(text: "Hello", isFinal: true)
+
+    TestRunner.assertTrue(a == b, "same text and isFinal are equal")
+    TestRunner.assertFalse(a == c, "different text not equal")
+    TestRunner.assertFalse(a == d, "different isFinal not equal")
+}
+
+func testTranscriptionUpdateEdgeCases() {
+    TestRunner.suite("TranscriptionUpdate Edge Cases")
+
+    let empty = TranscriptionUpdate(text: "", isFinal: false)
+    TestRunner.assertEqual(empty.text, "", "empty text is empty string")
+
+    let whitespace = TranscriptionUpdate(text: "   ", isFinal: false)
+    TestRunner.assertEqual(whitespace.text, "   ", "whitespace-only text preserved")
+
+    let zeroConfidence = TranscriptionUpdate(text: "test", isFinal: true, confidence: 0.0)
+    TestRunner.assertEqual(zeroConfidence.confidence, 0.0, "zero confidence is valid")
+
+    let maxConfidence = TranscriptionUpdate(text: "test", isFinal: true, confidence: 1.0)
+    TestRunner.assertEqual(maxConfidence.confidence, 1.0, "max confidence is valid")
+
+    let longText = TranscriptionUpdate(text: String(repeating: "word ", count: 1000), isFinal: true)
+    TestRunner.assertEqual(longText.text.count, 5000, "long text preserved")
+}
+
+func testTranscriptionUpdateConfidenceEquality() {
+    TestRunner.suite("TranscriptionUpdate Confidence Equality")
+
+    let withConfidence = TranscriptionUpdate(text: "hi", isFinal: false, confidence: 0.5)
+    let withoutConfidence = TranscriptionUpdate(text: "hi", isFinal: false)
+    TestRunner.assertFalse(withConfidence == withoutConfidence, "nil vs non-nil confidence not equal")
+
+    let sameConfidence1 = TranscriptionUpdate(text: "hi", isFinal: false, confidence: 0.8)
+    let sameConfidence2 = TranscriptionUpdate(text: "hi", isFinal: false, confidence: 0.8)
+    TestRunner.assertTrue(sameConfidence1 == sameConfidence2, "same confidence values equal")
+}
+
+// MARK: - VoiceInputConfiguration Tests
+
+func testVoiceInputConfigurationDefaults() {
+    TestRunner.suite("VoiceInputConfiguration Defaults")
+
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: "voiceInput.silenceTimeout")
+    defaults.removeObject(forKey: "voiceInput.maxDuration")
+    defaults.removeObject(forKey: "voiceInput.showWaveform")
+
+    let config = VoiceInputConfiguration()
+
+    TestRunner.assertEqual(config.silenceTimeoutSeconds, 3.0, "default silence timeout is 3.0s")
+    TestRunner.assertEqual(config.maxDurationSeconds, 60.0, "default max duration is 60.0s")
+    TestRunner.assertTrue(config.showWaveformIndicator, "default showWaveform is true")
+}
+
+func testVoiceInputConfigurationCustomValues() {
+    TestRunner.suite("VoiceInputConfiguration Custom Values")
+
+    var config = VoiceInputConfiguration()
+
+    config.silenceTimeoutSeconds = 5.0
+    TestRunner.assertEqual(config.silenceTimeoutSeconds, 5.0, "custom silence timeout persists")
+
+    config.maxDurationSeconds = 30.0
+    TestRunner.assertEqual(config.maxDurationSeconds, 30.0, "custom max duration persists")
+
+    config.showWaveformIndicator = false
+    TestRunner.assertFalse(config.showWaveformIndicator, "custom showWaveform persists")
+
+    // Clean up
+    UserDefaults.standard.removeObject(forKey: "voiceInput.silenceTimeout")
+    UserDefaults.standard.removeObject(forKey: "voiceInput.maxDuration")
+    UserDefaults.standard.removeObject(forKey: "voiceInput.showWaveform")
+}
+
+func testVoiceInputConfigurationConstants() {
+    TestRunner.suite("VoiceInputConfiguration Constants")
+
+    TestRunner.assertEqual(VoiceInputConfiguration.defaultSilenceTimeout, 3.0, "defaultSilenceTimeout constant is 3.0")
+    TestRunner.assertEqual(VoiceInputConfiguration.defaultMaxDuration, 60.0, "defaultMaxDuration constant is 60.0")
+}
+
+func testVoiceInputConfigurationBoundaryValues() {
+    TestRunner.suite("VoiceInputConfiguration Boundary Values")
+
+    var config = VoiceInputConfiguration()
+
+    // Very small values
+    config.silenceTimeoutSeconds = 0.1
+    TestRunner.assertEqual(config.silenceTimeoutSeconds, 0.1, "very small silence timeout works")
+
+    // Very large values
+    config.maxDurationSeconds = 3600.0
+    TestRunner.assertEqual(config.maxDurationSeconds, 3600.0, "large max duration works")
+
+    // Clean up
+    UserDefaults.standard.removeObject(forKey: "voiceInput.silenceTimeout")
+    UserDefaults.standard.removeObject(forKey: "voiceInput.maxDuration")
+}
+
+// MARK: - VoicePermissionStatus Tests
+
+func testVoicePermissionStatus() {
+    TestRunner.suite("VoicePermissionStatus Equality")
+
+    TestRunner.assertTrue(VoicePermissionStatus.authorized == VoicePermissionStatus.authorized, "authorized equals authorized")
+    TestRunner.assertTrue(VoicePermissionStatus.microphoneDenied == VoicePermissionStatus.microphoneDenied, "microphoneDenied equals")
+    TestRunner.assertTrue(VoicePermissionStatus.speechRecognitionDenied == VoicePermissionStatus.speechRecognitionDenied, "speechRecognitionDenied equals")
+    TestRunner.assertTrue(VoicePermissionStatus.notDetermined == VoicePermissionStatus.notDetermined, "notDetermined equals")
+    TestRunner.assertTrue(VoicePermissionStatus.siriDisabled == VoicePermissionStatus.siriDisabled, "siriDisabled equals")
+    TestRunner.assertFalse(VoicePermissionStatus.authorized == VoicePermissionStatus.microphoneDenied, "different statuses not equal")
+}
+
+func testVoicePermissionStatusAllCombinations() {
+    TestRunner.suite("VoicePermissionStatus All Inequality Pairs")
+
+    let allStatuses: [VoicePermissionStatus] = [.authorized, .microphoneDenied, .speechRecognitionDenied, .notDetermined, .siriDisabled]
+
+    for i in 0..<allStatuses.count {
+        for j in 0..<allStatuses.count {
+            if i == j {
+                TestRunner.assertTrue(allStatuses[i] == allStatuses[j], "status[\(i)] equals itself")
+            } else {
+                TestRunner.assertFalse(allStatuses[i] == allStatuses[j], "status[\(i)] != status[\(j)]")
+            }
+        }
+    }
+}
+
+// MARK: - SpeechRecognitionError Tests
+
+func testSpeechRecognitionErrors() {
+    TestRunner.suite("SpeechRecognitionError Descriptions")
+
+    let unavailable = SpeechRecognitionError.recognizerUnavailable
+    TestRunner.assertNotNil(unavailable.errorDescription, "recognizerUnavailable has description")
+    TestRunner.assertTrue(
+        unavailable.errorDescription!.contains("Dictation"),
+        "recognizerUnavailable mentions Dictation"
+    )
+
+    let audioFail = SpeechRecognitionError.audioEngineFailure("No mic")
+    TestRunner.assertTrue(
+        audioFail.errorDescription!.contains("No mic"),
+        "audioEngineFailure includes detail"
+    )
+
+    let recFail = SpeechRecognitionError.recognitionFailed("Timeout")
+    TestRunner.assertTrue(
+        recFail.errorDescription!.contains("Timeout"),
+        "recognitionFailed includes detail"
+    )
+
+    let micDenied = SpeechRecognitionError.microphoneAccessDenied
+    TestRunner.assertTrue(
+        micDenied.errorDescription!.contains("Microphone"),
+        "microphoneAccessDenied mentions Microphone"
+    )
+
+    let speechDenied = SpeechRecognitionError.speechRecognitionDenied
+    TestRunner.assertTrue(
+        speechDenied.errorDescription!.contains("Speech Recognition"),
+        "speechRecognitionDenied mentions Speech Recognition"
+    )
+
+    let siriDisabled = SpeechRecognitionError.siriDisabled
+    TestRunner.assertNotNil(siriDisabled.errorDescription, "siriDisabled has description")
+    TestRunner.assertTrue(
+        siriDisabled.errorDescription!.contains("Dictation"),
+        "siriDisabled mentions Dictation"
+    )
+}
+
+func testSpeechRecognitionErrorLocalizedError() {
+    TestRunner.suite("SpeechRecognitionError LocalizedError Conformance")
+
+    // All cases should provide non-nil errorDescription
+    let allCases: [SpeechRecognitionError] = [
+        .recognizerUnavailable,
+        .audioEngineFailure("test"),
+        .recognitionFailed("test"),
+        .microphoneAccessDenied,
+        .speechRecognitionDenied,
+        .siriDisabled
+    ]
+
+    for error in allCases {
+        TestRunner.assertNotNil(error.errorDescription, "\(error) has errorDescription")
+    }
+}
+
+func testSpeechRecognitionErrorDetailPreservation() {
+    TestRunner.suite("SpeechRecognitionError Detail Preservation")
+
+    let details = ["short", String(repeating: "x", count: 500), "special chars: éàü & <tag>"]
+    for detail in details {
+        let audioErr = SpeechRecognitionError.audioEngineFailure(detail)
+        TestRunner.assertTrue(
+            audioErr.errorDescription!.contains(detail),
+            "audioEngineFailure preserves detail: '\(detail.prefix(20))...'"
+        )
+
+        let recErr = SpeechRecognitionError.recognitionFailed(detail)
+        TestRunner.assertTrue(
+            recErr.errorDescription!.contains(detail),
+            "recognitionFailed preserves detail: '\(detail.prefix(20))...'"
+        )
+    }
+}
+
+// MARK: - Entry Point
+
+@main
+struct VoiceInputModelsTests {
+    static func main() {
+        print("🧪 Voice Input Models Tests")
+        print("==================================================")
+
+        testVoiceInputStateProperties()
+        testVoiceInputStateEquality()
+        testTranscriptionUpdate()
+        testTranscriptionUpdateEquality()
+        testTranscriptionUpdateEdgeCases()
+        testTranscriptionUpdateConfidenceEquality()
+        testVoiceInputConfigurationDefaults()
+        testVoiceInputConfigurationCustomValues()
+        testVoiceInputConfigurationConstants()
+        testVoiceInputConfigurationBoundaryValues()
+        testVoicePermissionStatus()
+        testVoicePermissionStatusAllCombinations()
+        testSpeechRecognitionErrors()
+        testSpeechRecognitionErrorLocalizedError()
+        testSpeechRecognitionErrorDetailPreservation()
+
+        TestRunner.printSummary()
+        if TestRunner.failedCount > 0 { exit(1) }
+    }
+}

--- a/Extremis/UI/PromptWindow/ChatInputView.swift
+++ b/Extremis/UI/PromptWindow/ChatInputView.swift
@@ -19,6 +19,9 @@ struct ChatInputView: View {
     /// Called when user attempts to paste an image but the model doesn't support vision
     var onNonVisionPasteAttempt: (() -> Void)?
 
+    @ObservedObject private var voiceInput = VoiceInputManager.shared
+    /// Text that existed in the input field before voice recording started
+    @State private var preRecordingText: String = ""
     @State private var isFocused: Bool = false
     @State private var imageError: String?
     @State private var imageErrorDismissId: UUID = UUID()
@@ -87,6 +90,9 @@ struct ChatInputView: View {
             }
 
             HStack(alignment: .bottom, spacing: 8) {
+                // Voice input mic button (always available)
+                VoiceInputIndicator()
+
                 // Attachment buttons (only when vision is supported)
                 if supportsVision {
                     HStack(spacing: 4) {
@@ -174,6 +180,21 @@ struct ChatInputView: View {
             guard supportsVision else { return false }
             handleDroppedItems(providers)
             return true
+        }
+        .onChange(of: voiceInput.state) { newState in
+            if newState.isRecording {
+                // Capture existing text when recording starts (FR-012: append behavior)
+                preRecordingText = text
+            }
+        }
+        .onChange(of: voiceInput.partialTranscription) { newTranscription in
+            guard voiceInput.state.isRecording || !newTranscription.isEmpty else { return }
+            // Append transcription after any pre-existing text
+            if preRecordingText.isEmpty {
+                text = newTranscription
+            } else {
+                text = preRecordingText + " " + newTranscription
+            }
         }
     }
 
@@ -279,9 +300,14 @@ struct ChatInputView: View {
     // MARK: - Send Logic
 
     private func sendIfReady() {
+        // Stop voice recording before sending (finalize transcription first)
+        if voiceInput.state.isRecording {
+            voiceInput.stopRecording()
+        }
         guard canSend else { return }
         onSend()
         text = ""
+        preRecordingText = ""
         contentHeight = minHeight
     }
 

--- a/Extremis/UI/PromptWindow/PromptView.swift
+++ b/Extremis/UI/PromptWindow/PromptView.swift
@@ -16,6 +16,10 @@ struct PromptInputView: View {
     let onSummarize: () -> Void
     var onViewContext: (() -> Void)? = nil  // Optional callback to view full context
 
+    // Voice input
+    @ObservedObject private var voiceInput = VoiceInputManager.shared
+    @State private var preRecordingText: String = ""
+
     // Command palette support
     @StateObject private var commandPaletteVM = CommandPaletteViewModel()
     @State private var showCommandPalette = false
@@ -86,8 +90,11 @@ struct PromptInputView: View {
                 .padding(.horizontal)
                 .frame(minHeight: 100)
 
-                // Action buttons - Layout: [Hint] ... [Cancel] [Summarize?] [Primary Action]
+                // Action buttons - Layout: [Mic] [Hint] ... [Cancel] [Summarize?] [Primary Action]
                 HStack(spacing: 12) {
+                    // Voice input mic button
+                    VoiceInputIndicator()
+
                     // Hint text - contextual guidance (left-aligned)
                     Group {
                         Text("Enter your instruction")
@@ -133,6 +140,19 @@ struct PromptInputView: View {
                 }
                 .padding(.horizontal)
                 .padding(.bottom, 16)
+            }
+        }
+        .onChange(of: voiceInput.state) { newState in
+            if newState.isRecording {
+                preRecordingText = instructionText
+            }
+        }
+        .onChange(of: voiceInput.partialTranscription) { newTranscription in
+            guard voiceInput.state.isRecording || !newTranscription.isEmpty else { return }
+            if preRecordingText.isEmpty {
+                instructionText = newTranscription
+            } else {
+                instructionText = preRecordingText + " " + newTranscription
             }
         }
     }

--- a/Extremis/UI/PromptWindow/VoiceInputIndicator.swift
+++ b/Extremis/UI/PromptWindow/VoiceInputIndicator.swift
@@ -6,6 +6,11 @@ import SwiftUI
 /// Mic button that reflects VoiceInputManager state with visual feedback
 struct VoiceInputIndicator: View {
     @ObservedObject var voiceInput = VoiceInputManager.shared
+    @ObservedObject var stealth = StealthManager.shared
+
+    private var isDisabled: Bool {
+        voiceInput.state == .requesting || stealth.isStealthActive
+    }
 
     var body: some View {
         Button(action: { voiceInput.toggleRecording() }) {
@@ -21,13 +26,16 @@ struct VoiceInputIndicator: View {
                 )
         }
         .buttonStyle(.plain)
-        .disabled(voiceInput.state == .requesting)
+        .disabled(isDisabled)
         .help(helpText)
     }
 
     // MARK: - Visual State
 
     private var micIcon: Image {
+        if stealth.isStealthActive {
+            return Image(systemName: "mic.slash")
+        }
         switch voiceInput.state {
         case .idle, .requesting:
             return Image(systemName: "mic")
@@ -39,6 +47,9 @@ struct VoiceInputIndicator: View {
     }
 
     private var iconColor: Color {
+        if stealth.isStealthActive {
+            return .secondary.opacity(0.3)
+        }
         switch voiceInput.state {
         case .idle:
             return .secondary
@@ -52,6 +63,9 @@ struct VoiceInputIndicator: View {
     }
 
     private var helpText: String {
+        if stealth.isStealthActive {
+            return "Voice input disabled in stealth mode"
+        }
         switch voiceInput.state {
         case .idle:
             return "Voice input (Option+D)"

--- a/Extremis/UI/PromptWindow/VoiceInputIndicator.swift
+++ b/Extremis/UI/PromptWindow/VoiceInputIndicator.swift
@@ -1,0 +1,66 @@
+// MARK: - Voice Input Indicator
+// Mic button component with recording state visualization
+
+import SwiftUI
+
+/// Mic button that reflects VoiceInputManager state with visual feedback
+struct VoiceInputIndicator: View {
+    @ObservedObject var voiceInput = VoiceInputManager.shared
+
+    var body: some View {
+        Button(action: { voiceInput.toggleRecording() }) {
+            micIcon
+                .font(.system(size: 16))
+                .foregroundColor(iconColor)
+                .scaleEffect(voiceInput.state.isRecording ? 1.15 : 1.0)
+                .animation(
+                    voiceInput.state.isRecording
+                        ? DS.Animation.expandCollapse.repeatForever(autoreverses: true)
+                        : .default,
+                    value: voiceInput.state.isRecording
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(voiceInput.state == .requesting)
+        .help(helpText)
+    }
+
+    // MARK: - Visual State
+
+    private var micIcon: Image {
+        switch voiceInput.state {
+        case .idle, .requesting:
+            return Image(systemName: "mic")
+        case .recording:
+            return Image(systemName: "mic.fill")
+        case .error:
+            return Image(systemName: "mic.slash")
+        }
+    }
+
+    private var iconColor: Color {
+        switch voiceInput.state {
+        case .idle:
+            return .secondary
+        case .requesting:
+            return .secondary.opacity(0.5)
+        case .recording:
+            return .red
+        case .error:
+            return .secondary
+        }
+    }
+
+    private var helpText: String {
+        switch voiceInput.state {
+        case .idle:
+            return "Voice input (Option+D)"
+        case .requesting:
+            return "Requesting permission..."
+        case .recording:
+            return "Recording... tap to stop"
+        case .error(let message):
+            return message
+        }
+    }
+}

--- a/Extremis/scripts/run-dev.sh
+++ b/Extremis/scripts/run-dev.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Development runner for Extremis
+# Creates a minimal .app bundle from the debug build so TCC (microphone, speech)
+# permissions work correctly. Runs the binary directly so logs appear in terminal.
+#
+# Usage: ./scripts/run-dev.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+APP_NAME="Extremis"
+DEV_BUNDLE="$PROJECT_DIR/.build/dev/${APP_NAME}.app"
+
+cd "$PROJECT_DIR"
+
+# Build debug
+echo "Building debug..."
+swift build 2>&1
+
+# Create minimal .app bundle
+rm -rf "$DEV_BUNDLE"
+mkdir -p "$DEV_BUNDLE/Contents/MacOS"
+
+# Copy binary
+cp ".build/debug/Extremis" "$DEV_BUNDLE/Contents/MacOS/"
+
+# Copy Info.plist (required for TCC privacy permissions)
+cp "Info.plist" "$DEV_BUNDLE/Contents/"
+
+# Copy SPM resource bundle into Contents/Resources (must be sealed inside the bundle
+# for codesign to succeed — placing at bundle root causes "unsealed contents" error)
+RESOURCE_BUNDLE=".build/debug/Extremis_Extremis.bundle"
+if [ -d "$RESOURCE_BUNDLE" ]; then
+    mkdir -p "$DEV_BUNDLE/Contents/Resources"
+    cp -r "$RESOURCE_BUNDLE" "$DEV_BUNDLE/Contents/Resources/"
+fi
+
+# Create PkgInfo
+echo -n "APPL????" > "$DEV_BUNDLE/Contents/PkgInfo"
+
+# Ad-hoc code sign the full .app bundle so TCC can bind Info.plist and resolve the
+# bundle identifier (com.extremis.app). Required on macOS 26+ for privacy permission prompts.
+# Use a dev-specific entitlements plist without keychain-access-groups (the production
+# entitlements contain $(AppIdentifierPrefix), an unresolved Xcode variable that
+# causes SIGKILL on ad-hoc signed binaries).
+DEV_ENTITLEMENTS="$PROJECT_DIR/.build/dev-entitlements.plist"
+/usr/libexec/PlistBuddy -c "Clear dict" "$DEV_ENTITLEMENTS" 2>/dev/null || plutil -create xml1 "$DEV_ENTITLEMENTS"
+/usr/libexec/PlistBuddy -c "Add :com.apple.security.app-sandbox bool false" "$DEV_ENTITLEMENTS"
+/usr/libexec/PlistBuddy -c "Add :com.apple.security.automation.apple-events bool true" "$DEV_ENTITLEMENTS"
+/usr/libexec/PlistBuddy -c "Add :com.apple.security.network.client bool true" "$DEV_ENTITLEMENTS"
+/usr/libexec/PlistBuddy -c "Add :com.apple.security.device.audio-input bool true" "$DEV_ENTITLEMENTS"
+
+echo "Signing (ad-hoc, hardened runtime)..."
+codesign --force --sign - --options runtime --identifier "com.extremis.app" --entitlements "$DEV_ENTITLEMENTS" "$DEV_BUNDLE"
+
+echo "Launching with logs..."
+echo "=========================================="
+echo "Logs stream below. Press Ctrl+C to stop (also quits Extremis)."
+echo ""
+
+# Launch via `open` so the app gets its own process coalition.
+# macOS 26 TCC checks the coalition for privacy keys — running via `exec` from a terminal
+# inherits the terminal's coalition (e.g., VSCode), causing TCC crashes for microphone/speech.
+open "$DEV_BUNDLE"
+
+# Give the app a moment to start, then stream its logs.
+sleep 1
+LOG_PID=$(pgrep -n -x Extremis)
+
+# On Ctrl+C, also quit the app
+cleanup() {
+    if [ -n "$LOG_PID" ]; then
+        kill "$LOG_PID" 2>/dev/null
+    fi
+    exit 0
+}
+trap cleanup INT TERM
+
+if [ -n "$LOG_PID" ]; then
+    log stream --process "$LOG_PID" --style compact 2>/dev/null
+else
+    echo "Warning: Could not find Extremis process for log streaming."
+    echo "Check Console.app for logs, or run: log stream --process Extremis"
+    wait
+fi

--- a/Extremis/scripts/run-tests.sh
+++ b/Extremis/scripts/run-tests.sh
@@ -286,6 +286,16 @@ run_test_suite "ClaudeCodeProvider Tests" \
     "$PROJECT_DIR/Tests/LLMProviders/ClaudeCodeProviderTests.swift" \
     "Foundation"
 
+# 37. VoiceInputModels Tests (VoiceInputState, TranscriptionUpdate, VoiceInputConfiguration)
+run_test_suite "VoiceInputModels Tests" \
+    "$PROJECT_DIR/Tests/Core/VoiceInputModelsTests.swift" \
+    "Foundation"
+
+# 38. SpeechRecognitionService Tests (CMSampleBuffer conversion, error classification)
+run_test_suite "SpeechRecognitionService Tests" \
+    "$PROJECT_DIR/Tests/Core/SpeechRecognitionServiceTests.swift" \
+    "Foundation" "AVFoundation" "CoreMedia" "CoreAudio"
+
 # ------------------------------------------------------------------------------
 # Final Summary
 # ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Instantly summarize selected text with one keystroke. Does nothing without a sel
 
 ### `Option+D` — Voice Input
 
-Toggle voice recording to dictate prompts. Speech is transcribed in real-time using on-device recognition (requires Siri enabled). Tap the mic button in the input field or press `Option+D` from anywhere. Text appends to existing input. Recording auto-stops after 3 seconds of silence or 60 seconds max.
+Toggle voice recording to dictate prompts. Speech is transcribed in real-time using on-device recognition (requires Siri enabled). Tap the mic button in the input field or press `Option+D` from anywhere. Text appends to existing input. Recording auto-stops after 3 seconds of silence or 60 seconds max. Voice input is automatically disabled in stealth mode to prevent the macOS mic indicator from appearing in the menu bar.
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ https://github.com/user-attachments/assets/71bd737a-529a-4c46-9366-9853b3f3c7fe
 - **Multi-Provider** — OpenAI, Anthropic, Google Gemini, and Ollama (local models)
 - **Smart Text Insertion** — Results insert directly at your cursor with `Cmd+Enter`
 - **Image Attachments** — Paste, drag-and-drop, or pick images to send with messages. Screenshot button captures what's behind Extremis
+- **Voice Input** — Speak to prompt via microphone. On-device speech recognition (SFSpeechRecognizer), live transcription, mic button or `Option+D` toggle
 - **Stealth Mode** — Invisible to screen sharing, screenshots, and recordings. Adjustable transparency, sound suppression, process disguise. Toggle with `Option+Shift+S`
 
 ## Requirements
@@ -107,6 +108,10 @@ To use a remote Ollama server, update the base URL in Preferences.
 
 Instantly summarize selected text with one keystroke. Does nothing without a selection.
 
+### `Option+D` — Voice Input
+
+Toggle voice recording to dictate prompts. Speech is transcribed in real-time using on-device recognition (requires Siri enabled). Tap the mic button in the input field or press `Option+D` from anywhere. Text appends to existing input. Recording auto-stops after 3 seconds of silence or 60 seconds max.
+
 ### Commands
 
 - **Pinned Commands Bar** — One-click access to frequently used prompts (Proofread, Professionalize, Simplify, Explain Code) shown above the input field
@@ -134,6 +139,7 @@ Commands automatically operate on selected text when available.
 | `Cmd+C` | Copy generated text |
 | `Option+Return` | Allow all tool calls |
 | `Option+Escape` | Deny all tool calls |
+| `Option+D` | Toggle Voice Input |
 | `Option+Shift+S` | Toggle Stealth Mode |
 | `Option+Shift+,` | Open Preferences (when menu bar hidden) |
 | `Escape` | Close window |

--- a/specs/015-voice-input/checklists/requirements.md
+++ b/specs/015-voice-input/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Voice Input
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All clarifications resolved. FR-013 scoped to English only per user decision.

--- a/specs/015-voice-input/data-model.md
+++ b/specs/015-voice-input/data-model.md
@@ -1,0 +1,87 @@
+# Data Model: Voice Input (015)
+
+**Date**: 2026-05-22
+**Branch**: `015-voice-input`
+
+## Entities
+
+### VoiceInputState (Observable Enum)
+
+Represents the current state of the voice input system, driven by `VoiceInputManager`.
+
+```
+States:
+  idle          — No recording active. Mic button shows default appearance.
+  requesting    — Permission being requested. Mic button disabled.
+  recording     — Actively recording and transcribing. Visual indicator active.
+  error(String) — An error occurred. Shows inline error message, auto-dismisses.
+
+Transitions:
+  idle → requesting        : User taps mic / presses Option+D (first time, permission not granted)
+  idle → recording         : User taps mic / presses Option+D (permission already granted)
+  requesting → recording   : Permission granted
+  requesting → error       : Permission denied
+  requesting → idle        : User cancels permission dialog
+  recording → idle         : User stops recording (button tap/Option+D toggle/silence timeout/60s max)
+  recording → error        : Mic disconnected, recognizer unavailable, audio engine failure
+  error → idle             : Error auto-dismissed after 3 seconds
+```
+
+### TranscriptionUpdate
+
+A value emitted by the speech recognition stream for each partial or final result.
+
+```
+Fields:
+  text: String           — The current best transcription (replaces previous partial)
+  isFinal: Bool          — Whether this is the final, definitive result
+  confidence: Double?    — Optional confidence score (0.0–1.0) from recognizer
+```
+
+### VoiceInputConfiguration (UserDefaults-backed)
+
+User-configurable settings for voice input behavior.
+
+```
+Fields:
+  silenceTimeoutSeconds: Double    — Seconds of silence before auto-stop (default: 3.0)
+  maxDurationSeconds: Double       — Maximum recording duration (default: 60.0)
+  showWaveformIndicator: Bool      — Whether to show animated waveform during recording (default: true)
+
+Storage:
+  UserDefaults keys prefixed with "voiceInput." (e.g., "voiceInput.silenceTimeout")
+```
+
+## Relationships
+
+```
+VoiceInputManager (singleton, @MainActor)
+├── owns → VoiceInputState (published, drives UI)
+├── owns → VoiceInputConfiguration (reads settings)
+└── uses → SpeechRecognitionService (start/stop recording, receive transcription stream)
+
+SpeechRecognitionService
+├── owns → AVAudioEngine (microphone capture)
+├── owns → SFSpeechRecognizer (on-device recognition)
+├── owns → SFSpeechAudioBufferRecognitionRequest (per-session)
+├── owns → SFSpeechRecognitionTask (per-session)
+└── emits → AsyncThrowingStream<TranscriptionUpdate, Error>
+
+HotkeyManager (existing singleton — no new component)
+└── registers → Option+D as HotkeyIdentifier.voiceInput
+    → callback: VoiceInputManager.shared.toggleRecording()
+
+ChatInputView / PromptView (UI)
+├── reads → VoiceInputManager.state (recording indicator, error display)
+├── reads → VoiceInputManager.partialTranscription (live text in input field)
+└── calls → VoiceInputManager.toggleRecording() (mic button action)
+```
+
+## No Persistence Required
+
+Per spec assumption A-004: "No audio is stored or persisted — transcription happens in real-time and only the resulting text is kept."
+
+- Audio buffers are transient (consumed by recognizer, not retained)
+- Transcribed text flows into the existing `@Binding var text: String` in the input field
+- Once sent as a chat message, the text is persisted via the existing `ChatMessage` / `JSONSessionStorage` pipeline
+- No new persistence layer needed for voice input

--- a/specs/015-voice-input/plan.md
+++ b/specs/015-voice-input/plan.md
@@ -1,0 +1,219 @@
+# Implementation Plan: Voice Input
+
+**Branch**: `015-voice-input` | **Date**: 2026-05-22 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/015-voice-input/spec.md`
+
+## Summary
+
+Add voice-to-text input to Extremis using Apple's `SFSpeechRecognizer` with on-device recognition. Users speak into their microphone via a mic button or Fn hold-to-talk shortcut; speech is transcribed in real-time into the existing text input field. All LLM responses remain text-only. The feature is additive — no existing input flows are modified.
+
+## Technical Context
+
+**Language/Version**: Swift 5.9+
+**Primary Dependencies**: Speech framework (SFSpeechRecognizer), AVFoundation (AVAudioEngine), Carbon (existing), ApplicationServices (existing)
+**Storage**: N/A — no audio or transcription persisted; text flows into existing ChatMessage pipeline
+**Testing**: Standalone Swift test files via `scripts/run-tests.sh` (existing pattern)
+**Target Platform**: macOS 13.0+ (Ventura)
+**Project Type**: Single macOS app (existing Extremis structure)
+**Performance Goals**: Transcription visible within 1 second of speech; recording start <100ms perceived latency
+**Constraints**: On-device only (no network), English only, 60-second max recording, no audio stored
+**Scale/Scope**: Single-user desktop app; one concurrent voice session
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Modularity & Separation of Concerns | PASS | Three new files with distinct responsibilities: `VoiceInputManager` (coordinator), `SpeechRecognitionService` (audio+recognition), `VoiceInputKeyHandler` (Fn key). No circular dependencies. |
+| II. Code Quality & Best Practices | PASS | Follows Swift API Design Guidelines. Named constants for timeouts/durations. Protocol-based where extensible. |
+| III. Extensibility & Testability | PASS | `SpeechRecognitionService` is injectable. Business logic separated from UI. Uses Swift Concurrency (`async/await`, `AsyncThrowingStream`). |
+| IV. User Experience Excellence | PASS | <100ms perceived start latency. Visual recording indicator with animation. Clear error states with actionable guidance. Fn shortcut is discoverable. |
+| V. Documentation Synchronization | PASS | README and CLAUDE.md to be updated with new feature documentation. |
+| VI. Testing Discipline | PASS | Unit tests for state machine, configuration, key handler logic, transcription update model. Edge cases from spec covered. |
+| VII. Regression Prevention | PASS | Feature is purely additive — new files, new UI element in existing HStack. No modification to existing hotkey, LLM, or chat flows. Existing tests must continue passing. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/015-voice-input/
+├── spec.md
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+Extremis/
+├── Core/
+│   ├── Models/
+│   │   └── VoiceInputModels.swift          # VoiceInputState, TranscriptionUpdate, VoiceInputConfiguration
+│   └── Services/
+│       ├── VoiceInputManager.swift         # @MainActor singleton coordinator
+│       └── SpeechRecognitionService.swift   # AVAudioEngine + SFSpeechRecognizer wrapper
+├── UI/
+│   └── PromptWindow/
+│       └── VoiceInputIndicator.swift       # Recording indicator overlay / inline component
+├── Package.swift                           # Add Speech, AVFoundation frameworks
+└── Info.plist                              # Add NSMicrophoneUsageDescription, NSSpeechRecognitionUsageDescription
+
+Tests/
+└── Core/
+    └── VoiceInputModelsTests.swift          # State transitions, configuration defaults
+```
+
+**Structure Decision**: Follows existing Extremis directory conventions. New models go in `Core/Models/`, new services in `Core/Services/`, new UI in `UI/PromptWindow/`. No new top-level directories needed.
+
+## Architecture
+
+### Component Diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    UI Layer                                   │
+│                                                               │
+│  ┌─────────────────┐    ┌──────────────────┐                 │
+│  │ ChatInputView   │    │ PromptView       │                 │
+│  │ (mic button)    │    │ (mic button)     │                 │
+│  │ @Binding text   │    │ @Binding text    │                 │
+│  └────────┬────────┘    └────────┬─────────┘                 │
+│           │                      │                            │
+│  ┌────────▼──────────────────────▼─────────┐                 │
+│  │       VoiceInputIndicator               │                 │
+│  │       (recording state visual)          │                 │
+│  └────────┬────────────────────────────────┘                 │
+│           │ reads state                                       │
+├───────────┼──────────────────────────────────────────────────┤
+│           │          Service Layer                            │
+│           │                                                   │
+│  ┌────────▼────────────────────────────────┐                 │
+│  │       VoiceInputManager.shared          │                 │
+│  │       (@MainActor singleton)            │                 │
+│  │                                         │                 │
+│  │  @Published state: VoiceInputState      │                 │
+│  │  @Published partialText: String         │                 │
+│  │  configuration: VoiceInputConfiguration │                 │
+│  │                                         │                 │
+│  │  toggleRecording()                      │                 │
+│  │  startRecording()                       │                 │
+│  │  stopRecording()                        │                 │
+│  └──────┬──────────────────────────────────┘                 │
+│         │                                                    │
+│  ┌──────▼───────────────────────┐                            │
+│  │ SpeechRecognitionService     │                            │
+│  │                              │                            │
+│  │ AVAudioEngine                │                            │
+│  │ SFSpeechRecognizer           │                            │
+│  │ → AsyncThrowingStream        │                            │
+│  └──────────────────────────────┘                            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+```
+1. User taps mic button OR holds Fn key
+2. VoiceInputManager.toggleRecording() / startRecording() called
+3. VoiceInputManager checks permission (SFSpeechRecognizer.authorizationStatus)
+   - Not determined → request authorization → on grant, continue
+   - Denied → set state to .error with guidance message → return
+   - Authorized → continue
+4. VoiceInputManager sets state = .recording
+5. SpeechRecognitionService.startTranscription() called
+   - Creates SFSpeechAudioBufferRecognitionRequest (requiresOnDeviceRecognition = true)
+   - Installs tap on AVAudioEngine.inputNode
+   - Starts AVAudioEngine
+   - Starts SFSpeechRecognitionTask
+   - Returns AsyncThrowingStream<TranscriptionUpdate, Error>
+6. VoiceInputManager consumes stream:
+   - Partial results → updates partialText (UI sees live transcription)
+   - Final result → updates partialText with final text
+   - Error → sets state = .error
+7. User stops recording (button tap / Fn release / silence timeout / 60s max)
+8. VoiceInputManager.stopRecording() called
+   - SpeechRecognitionService.stopTranscription()
+   - Waits for final result
+   - Appends final text to the input field's text binding
+   - Sets state = .idle
+```
+
+### Key Design Decisions
+
+#### 1. Additive-Only Changes to Existing Files
+
+The only existing files that need modification:
+
+| File | Change | Risk |
+|---|---|---|
+| `ChatInputView.swift` | Add mic `Button` in left HStack, outside `supportsVision` guard | Minimal — adding one button to an HStack |
+| `PromptView.swift` | Add mic `Button` in action button area | Minimal — same pattern |
+| `Package.swift` | Add `.linkedFramework("Speech")`, `.linkedFramework("AVFoundation")` | Zero risk — additive linker settings |
+| `Info.plist` | Add 2 usage description keys | Zero risk — additive plist entries |
+| `PermissionManager.swift` | Add `microphoneStatus` and `speechRecognitionStatus` computed properties | Minimal — additive methods |
+| `HotkeyManager.swift` | Add `case voiceInput = 5` to `HotkeyIdentifier` enum | Minimal — one new enum case |
+| `AppDelegate.swift` | Register Option+D hotkey for voice input toggle | Minimal — follows existing hotkey registration pattern |
+
+No existing code paths are modified. No existing function signatures change.
+
+#### 2. Keyboard Shortcut (Option+D Toggle)
+
+Uses the existing Carbon `RegisterEventHotKey` mechanism via `HotkeyManager`:
+
+```
+Register Option+D as HotkeyIdentifier.voiceInput (rawValue 5)
+Callback: VoiceInputManager.shared.toggleRecording()
+
+Toggle behavior:
+  - If idle → startRecording()
+  - If recording → stopRecording()
+```
+
+No new `NSEvent` monitor or `VoiceInputKeyHandler` needed. The existing `HotkeyManager` handles everything, keeping the implementation simple and consistent with Option+Space, Option+Tab, Option+Shift+S.
+
+#### 3. Silence Timeout Detection
+
+The `SFSpeechRecognitionTask` callback fires with partial results as speech is detected. Silence is detected by tracking the time since the last partial result update:
+
+```
+silenceTimer starts when recording begins
+On each partial result → reset silenceTimer
+If silenceTimer fires (3s default) → stopRecording()
+```
+
+#### 4. Recording State Visual Indicator
+
+The mic button changes appearance based on `VoiceInputState`:
+
+| State | Mic Button Appearance |
+|---|---|
+| `.idle` | `mic` SF Symbol, `.secondary` color, `.plain` button style |
+| `.recording` | `mic.fill` SF Symbol, `.red` color, pulsing animation (`DS.Animation.expandCollapse`) |
+| `.error` | `mic.slash` SF Symbol, `.secondary` color, tooltip with error message |
+
+Additionally, during `.recording`, a subtle red border or glow appears around the input field using `DS.Colors.errorBorder`.
+
+#### 5. Text Append Behavior (FR-012)
+
+When the user already has text in the input field and activates voice input:
+- Transcribed text is **appended** at the end of existing text, separated by a space
+- The user can edit the combined text before sending
+- If the input field is empty, transcribed text starts from the beginning
+
+## Complexity Tracking
+
+> No constitution violations detected. All design choices use the simplest available approach.
+
+| Aspect | Approach | Why Simplest |
+|---|---|---|
+| Speech recognition | Apple built-in SFSpeechRecognizer | System framework, no external deps |
+| Fn key detection | NSEvent global monitor | Simpler than CGEventTap or IOKit HID |
+| State management | Observable singleton + enum | Matches existing Extremis patterns |
+| Audio capture | AVAudioEngine single tap | Standard Apple pattern, minimal code |
+| UI integration | Button in existing HStack | No new views/controllers needed |
+| Configuration | UserDefaults | Matches existing preferences pattern |

--- a/specs/015-voice-input/quickstart.md
+++ b/specs/015-voice-input/quickstart.md
@@ -1,0 +1,70 @@
+# Quickstart: Voice Input (015)
+
+## Prerequisites
+
+- macOS 13.0+ (Ventura)
+- Microphone (built-in or external)
+- Siri enabled in System Settings (required for on-device speech recognition)
+
+## New Frameworks
+
+Add to `Package.swift` linker settings:
+```swift
+.linkedFramework("Speech")
+.linkedFramework("AVFoundation")
+```
+
+## Info.plist Keys
+
+```xml
+<key>NSMicrophoneUsageDescription</key>
+<string>Extremis uses your microphone to transcribe voice input into text prompts.</string>
+<key>NSSpeechRecognitionUsageDescription</key>
+<string>Extremis uses on-device speech recognition to convert your voice to text.</string>
+```
+
+## New Files to Create
+
+| File | Purpose |
+|---|---|
+| `Core/Models/VoiceInputModels.swift` | VoiceInputState enum, TranscriptionUpdate, VoiceInputConfiguration |
+| `Core/Services/VoiceInputManager.swift` | @MainActor singleton coordinator |
+| `Core/Services/SpeechRecognitionService.swift` | AVAudioEngine + SFSpeechRecognizer |
+| `UI/PromptWindow/VoiceInputIndicator.swift` | Recording state visual component |
+| `Tests/Core/VoiceInputModelsTests.swift` | State machine and config tests |
+
+## Existing Files to Modify
+
+| File | Change |
+|---|---|
+| `UI/PromptWindow/ChatInputView.swift` | Add mic button in left HStack |
+| `UI/PromptWindow/PromptView.swift` | Add mic button in action area |
+| `Core/Services/PermissionManager.swift` | Add microphone + speech recognition status |
+| `Core/Services/HotkeyManager.swift` | Add `case voiceInput = 5` to HotkeyIdentifier |
+| `App/AppDelegate.swift` | Register Option+D hotkey for voice input toggle |
+| `Package.swift` | Add Speech, AVFoundation frameworks |
+
+## Core API Surface
+
+```swift
+// Start/stop voice input
+VoiceInputManager.shared.toggleRecording()
+VoiceInputManager.shared.startRecording()
+VoiceInputManager.shared.stopRecording()
+
+// Observe state in SwiftUI
+@ObservedObject var voiceInput = VoiceInputManager.shared
+// voiceInput.state — VoiceInputState (.idle, .recording, .error)
+// voiceInput.partialTranscription — String (live text while recording)
+
+// Check permissions
+VoiceInputManager.shared.checkPermissions() -> VoicePermissionStatus
+VoiceInputManager.shared.requestPermissions() async -> Bool
+```
+
+## Build & Test
+
+```bash
+cd Extremis && swift build
+cd Extremis && ./scripts/run-tests.sh
+```

--- a/specs/015-voice-input/research.md
+++ b/specs/015-voice-input/research.md
@@ -1,0 +1,108 @@
+# Research: Voice Input (015)
+
+**Date**: 2026-05-22
+**Branch**: `015-voice-input`
+
+## Decision 1: Speech Recognition Framework
+
+**Decision**: Use Apple's `SFSpeechRecognizer` (Speech framework) with `requiresOnDeviceRecognition = true`.
+
+**Rationale**:
+- Available on macOS 10.15+; our target macOS 13.0+ is fully covered
+- On-device mode: zero network dependency, zero rate limits, no duration limits
+- English on-device recognition supported on all Apple Silicon and Intel Macs with macOS 13+
+- `shouldReportPartialResults = true` provides real-time streaming partial transcription
+- `AVAudioEngine` microphone tap is a single `.installTap()` call
+- `AsyncThrowingStream` pattern fits naturally into Extremis's existing LLM streaming architecture
+- No external dependencies — `Speech` and `AVFoundation` are system frameworks
+
+**Alternatives considered**:
+
+| Alternative | Why Rejected |
+|---|---|
+| `NSSpeechRecognizer` (AppKit) | Command-recognition only — no free-form transcription, no partial results |
+| Apple System Dictation | Not programmatically accessible — no public API to start/stop or capture output |
+| Whisper.cpp / WhisperKit | Overkill for menu bar app. WhisperKit requires macOS 14+ (conflicts with our macOS 13 target). Raw whisper.cpp needs C bridging, ~273MB–3.9GB RAM per model. Complex integration for marginal accuracy gain |
+
+**Gotcha**: `SFSpeechRecognizer` requires Siri to be enabled in System Settings for on-device mode. If Siri is disabled, `supportsOnDeviceRecognition` returns `false`. The app should detect this and show clear guidance.
+
+## Decision 2: Keyboard Shortcut — Option+D Toggle
+
+**Decision**: Use `Option+D` as a toggle shortcut (press to start, press to stop) via the existing Carbon `RegisterEventHotKey` mechanism in `HotkeyManager`.
+
+**Rationale**:
+- Uses the existing `HotkeyManager` Carbon hotkey system — no new event handling mechanism needed
+- "D" for Dictation — mnemonic and easy to remember
+- Follows established Extremis pattern: Option+Space, Option+Tab, Option+Shift+S
+- Toggle behavior is simpler than hold-to-talk (no key-up detection needed)
+- No system conflicts — Option+D is not reserved by macOS
+- Eliminates the need for `VoiceInputKeyHandler`, `NSEvent` global monitor, and Fn system-conflict detection
+
+**Alternatives considered**:
+
+| Alternative | Why Rejected |
+|---|---|
+| Fn key (hold-to-talk) | Carbon can't capture Fn; system conflict with Dictation/Emoji; requires NSEvent monitor and user System Settings changes |
+| `NSEvent.addGlobalMonitorForEvents` | Heavier mechanism; unnecessary when Carbon toggle works |
+| Option+V / Option+M | Less mnemonic than "D" for Dictation |
+| Hold-to-talk (any key) | Requires key-up detection; Carbon only fires key-down; would need separate NSEvent monitor |
+
+## Decision 3: Audio Engine Pattern
+
+**Decision**: Single `AVAudioEngine` instance owned by `SpeechRecognitionService`, with tap installed/removed per recording session.
+
+**Rationale**:
+- `audioEngine.inputNode.outputFormat(forBus: 0)` gives native hardware format — no manual resampling needed
+- macOS has no `AVAudioSession` category system (unlike iOS) — audio engine connects directly to hardware
+- `audioEngine.prepare()` before `audioEngine.start()` pre-allocates buffers, reducing start latency
+- Tap closure receives `AVAudioPCMBuffer` objects, passed to `request.append(buffer)` — no manual retention needed
+- Clean shutdown order: `engine.stop()` → `removeTap(onBus: 0)` → `request.endAudio()` → `task.finish()`
+
+## Decision 4: Service Architecture
+
+**Decision**: `@MainActor` singleton `VoiceInputManager` coordinating `SpeechRecognitionService` (audio + recognition). Keyboard shortcut handled by existing `HotkeyManager`. Expose transcription via `AsyncThrowingStream<String, Error>`.
+
+**Rationale**:
+- Matches Extremis's established singleton pattern (`HotkeyManager.shared`, `StealthManager.shared`)
+- `AsyncThrowingStream` mirrors the `LLMProvider.generateStream()` pattern already used for LLM responses
+- Keyboard shortcut uses existing `HotkeyManager` — no separate key handler component needed
+- `@MainActor` ensures thread safety for UI state updates (recording indicator, text binding)
+
+## Decision 5: UI Integration Points
+
+**Decision**: Mic button in `ChatInputView` button row (outside `supportsVision` guard). Write transcription to existing `@Binding var text: String`.
+
+**Rationale**:
+- `ChatInputView` already has attachment buttons (paperclip, camera) in an `HStack(spacing: 4)` — mic button fits the same pattern
+- Voice input is independent of vision capability, so it lives outside the `if supportsVision` conditional
+- Writing to `@Binding var text: String` automatically propagates to `NSTextView.string` via `updateNSView`
+- `canSend` flag (`!text.isEmpty || !pendingAttachments.isEmpty`) auto-enables send button when transcription appears
+- For Quick Mode (`PromptView.swift`), same pattern via `@Binding var instructionText: String`
+
+## Decision 6: Permission Requirements
+
+**Decision**: Two Info.plist keys + Speech framework authorization check.
+
+| Requirement | Key / API |
+|---|---|
+| Microphone access | `NSMicrophoneUsageDescription` in Info.plist |
+| Speech recognition | `NSSpeechRecognitionUsageDescription` in Info.plist |
+| Runtime check | `SFSpeechRecognizer.requestAuthorization()` on first voice input activation |
+| Denied state | Direct user to System Settings > Privacy > Speech Recognition / Microphone |
+
+No sandbox entitlement needed — Extremis has sandbox disabled.
+
+## Decision 7: Framework Dependencies
+
+**Decision**: Add `Speech` and `AVFoundation` as linked frameworks in `Package.swift`.
+
+```swift
+linkerSettings: [
+    .linkedFramework("Carbon"),
+    .linkedFramework("ApplicationServices"),
+    .linkedFramework("Speech"),        // SFSpeechRecognizer
+    .linkedFramework("AVFoundation"),  // AVAudioEngine
+]
+```
+
+No new Swift Package Manager dependencies required.

--- a/specs/015-voice-input/spec.md
+++ b/specs/015-voice-input/spec.md
@@ -1,0 +1,146 @@
+# Feature Specification: Voice Input
+
+**Feature Branch**: `015-voice-input`
+**Created**: 2026-05-22
+**Status**: Draft
+**Input**: User description: "Build voice support feature in extremis. I want to prompt via voice but extremis will still return me textual data only. It won't return voice data"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Voice Prompt via Microphone Button (Priority: P1)
+
+A user activates Extremis via their usual hotkey and, instead of typing, taps a microphone button to speak their prompt. Extremis transcribes the speech to text in real-time, displays the transcription in the input field, and sends it to the LLM as a normal text prompt. The LLM response is returned as text only — no audio playback.
+
+**Why this priority**: This is the core value proposition. Without basic voice-to-text input, no other voice features matter.
+
+**Independent Test**: Can be fully tested by activating the prompt window, tapping the mic button, speaking a phrase, and verifying the transcribed text appears in the input field and is sent to the LLM.
+
+**Acceptance Scenarios**:
+
+1. **Given** the prompt window is open, **When** the user taps the microphone button, **Then** the system begins listening and shows a visual recording indicator.
+2. **Given** the system is recording, **When** the user speaks a phrase, **Then** the spoken words appear in the input field as transcribed text in near real-time.
+3. **Given** transcription is complete, **When** the user confirms (presses Enter or taps send), **Then** the transcribed text is sent to the active LLM provider and the response is displayed as text.
+4. **Given** the system is recording, **When** the user taps the microphone button again, **Then** recording stops and the transcribed text remains in the input field for review or editing before sending.
+
+---
+
+### User Story 2 - Voice Input via Keyboard Shortcut (Priority: P2)
+
+A user triggers voice input directly via a keyboard shortcut (Option+D) without needing to click the microphone button. This enables a fast, keyboard-driven workflow — press the shortcut to start recording, press again to stop.
+
+**Why this priority**: Power users need a fast, keyboard-driven workflow. A shortcut for voice input removes friction.
+
+**Independent Test**: Can be tested by pressing Option+D, speaking, pressing Option+D again, and verifying the transcribed text is placed in the input field.
+
+**Acceptance Scenarios**:
+
+1. **Given** the prompt window is open and not recording, **When** the user presses Option+D, **Then** recording begins immediately with a visual indicator.
+2. **Given** recording is active, **When** the user presses Option+D again, **Then** recording stops and the transcribed text remains in the input field.
+3. **Given** the prompt window is not open, **When** the user presses Option+D, **Then** the prompt window opens and recording begins.
+
+---
+
+### User Story 3 - Live Transcription Feedback (Priority: P2)
+
+While the user is speaking, partial transcription results appear in the input field in real-time, giving the user confidence that their speech is being captured correctly.
+
+**Why this priority**: Real-time feedback is essential for a good voice input experience — without it, users cannot tell if their speech is being recognized correctly until after they stop.
+
+**Independent Test**: Can be tested by speaking a multi-word phrase and verifying that words appear progressively in the input field as they are spoken.
+
+**Acceptance Scenarios**:
+
+1. **Given** recording is active, **When** the user speaks continuously, **Then** partial transcription results appear in the input field progressively.
+2. **Given** partial results are displayed, **When** the system finalizes a segment, **Then** the partial text is replaced with the final, more accurate transcription.
+
+---
+
+### User Story 4 - Microphone Permission Handling (Priority: P3)
+
+When the user first attempts voice input, the system requests microphone permission if not already granted. If permission is denied, the system shows a clear message directing the user to System Settings.
+
+**Why this priority**: Necessary for a polished experience, but secondary to core functionality.
+
+**Independent Test**: Can be tested by revoking microphone permission and attempting voice input, verifying the appropriate guidance is shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** microphone permission has not been granted, **When** the user activates voice input, **Then** the system requests microphone access via the standard macOS permission dialog.
+2. **Given** microphone permission is denied, **When** the user attempts voice input, **Then** the system displays a message explaining how to grant permission in System Settings.
+3. **Given** microphone permission is granted, **When** the user activates voice input, **Then** recording begins without any permission prompts.
+
+---
+
+### User Story 5 - Voice Input in Chat Mode (Priority: P3)
+
+In an ongoing chat conversation, the user can use voice input for any message — not just the first prompt. The voice input integrates seamlessly with the existing chat flow.
+
+**Why this priority**: Natural extension of P1, but less critical than getting the initial voice input working.
+
+**Independent Test**: Can be tested by starting a chat, sending a typed message, then using voice input for a follow-up message in the same conversation.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active chat conversation, **When** the user activates voice input, **Then** the transcribed text is added to the input field for the current conversation.
+2. **Given** an active chat with tool calls in progress, **When** the user activates voice input, **Then** voice input works without interfering with ongoing tool execution.
+
+---
+
+### Edge Cases
+
+- What happens when the user speaks in a very noisy environment? The system should still attempt transcription and display whatever it captures — accuracy may degrade but the system should not crash or hang.
+- What happens when the microphone is disconnected during recording? The system should stop recording gracefully, retain any already-transcribed text, and show an appropriate message.
+- What happens when the user speaks for an extended period? The system should handle input up to 60 seconds maximum, then automatically stop recording and retain the transcribed text.
+- What happens when the user activates voice input but says nothing? After a silence timeout, the system should stop recording and leave the input field unchanged.
+- What happens when the user switches apps while recording? Recording should stop gracefully and retain any transcribed text.
+- What happens when voice input is used with Quick Mode (text selection present)? The voice input should work the same way — transcribed text replaces typed input and is sent alongside the selected text context.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a microphone button in the prompt window input area to initiate voice recording.
+- **FR-002**: System MUST transcribe spoken audio to text using on-device speech recognition (no external API dependency, no network required).
+- **FR-003**: System MUST display real-time partial transcription results in the input field as the user speaks.
+- **FR-004**: System MUST stop recording when the user explicitly stops it (button click or key release), after a silence timeout, or after reaching the 60-second maximum duration.
+- **FR-005**: System MUST allow the user to edit transcribed text before sending it to the LLM.
+- **FR-006**: System MUST show a clear visual indicator when recording is active (e.g., pulsing microphone icon, colored border).
+- **FR-007**: System MUST handle microphone permission requests and denials gracefully with user-friendly guidance.
+- **FR-008**: System MUST support voice input in all modes: Quick Mode, Chat Mode, and Command Mode.
+- **FR-009**: System MUST provide a keyboard shortcut (Option+D, toggle) for voice input activation. Press once to start recording, press again to stop.
+- **FR-010**: System MUST retain all transcribed text if recording is interrupted (mic disconnect, app switch, error).
+- **FR-011**: System MUST return LLM responses as text only — no audio output or text-to-speech.
+- **FR-012**: System MUST allow voice input to be used alongside existing text in the input field (append, not replace).
+- **FR-013**: System MUST support English language speech recognition only.
+
+### Key Entities
+
+- **VoiceSession**: Represents a single voice recording session — includes start/end timestamps, recording state, and the accumulated transcription text.
+- **TranscriptionResult**: A segment of transcribed text — may be partial (in-progress) or final (confirmed by the recognition engine).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can complete a voice-prompted interaction (speak, review, send) in under 10 seconds for a typical single-sentence prompt.
+- **SC-002**: Transcription appears in the input field within 1 second of the user speaking.
+- **SC-003**: Voice input works reliably across all three input modes (Quick, Chat, Command) without errors.
+- **SC-004**: Users can review and edit transcribed text before submission 100% of the time — no auto-send without user confirmation.
+- **SC-005**: System gracefully handles all error conditions (no permission, mic disconnect, silence) without crashing or hanging.
+- **SC-006**: Voice input adds no more than 1 additional user action compared to typed input (i.e., tap mic + speak vs. type).
+
+## Clarifications
+
+### Session 2026-05-22
+
+- Q: Should voice input be disabled or warned when stealth mode is active? → A: No special behavior — voice input works identically regardless of stealth mode.
+- Q: Which keyboard shortcut should trigger voice input? → A: Option+D (toggle: press to start, press again to stop). Follows existing Option+key pattern. Avoids Fn system conflicts.
+- Q: What is the maximum continuous recording duration? → A: 60 seconds. Recording auto-stops and retains transcribed text.
+
+## Assumptions
+
+- **A-001**: The operating system's built-in speech recognition provides sufficient transcription quality for the primary system language without requiring an external API.
+- **A-002**: The user has a working microphone connected to their Mac (built-in or external).
+- **A-003**: Voice input is a supplementary input method — keyboard text input remains the primary method and is unaffected.
+- **A-004**: No audio is stored or persisted — transcription happens in real-time and only the resulting text is kept.
+- **A-005**: Default silence timeout of 3 seconds is appropriate for most users.

--- a/specs/015-voice-input/tasks.md
+++ b/specs/015-voice-input/tasks.md
@@ -1,0 +1,230 @@
+# Tasks: Voice Input
+
+**Input**: Design documents from `/specs/015-voice-input/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, quickstart.md
+
+**Tests**: Included per CLAUDE.md requirement ("All new code MUST include unit tests").
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Add framework dependencies and permission keys required by all voice input features
+
+- [X] T001 Add Speech and AVFoundation linked frameworks in Extremis/Package.swift
+- [X] T002 [P] Add NSMicrophoneUsageDescription and NSSpeechRecognitionUsageDescription keys in Extremis/Info.plist
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core models, services, and permission infrastructure that MUST be complete before ANY user story can be implemented
+
+- [X] T003 Create VoiceInputState enum, TranscriptionUpdate struct, and VoiceInputConfiguration struct in Extremis/Core/Models/VoiceInputModels.swift
+- [X] T004 Create SpeechRecognitionService with AVAudioEngine + SFSpeechRecognizer, startTranscription() returning AsyncThrowingStream<TranscriptionUpdate, Error>, stopTranscription(), and proper cleanup in Extremis/Core/Services/SpeechRecognitionService.swift
+- [X] T005 Create VoiceInputManager @MainActor singleton with @Published state/partialTranscription, toggleRecording(), startRecording(), stopRecording(), silence timeout timer, 60-second max duration timer, and text append logic (FR-012) in Extremis/Core/Services/VoiceInputManager.swift
+- [X] T006 [P] Add microphoneStatus, speechRecognitionStatus computed properties and requestMicrophoneAccess(), requestSpeechRecognitionAccess() async methods to Extremis/Core/Services/PermissionManager.swift
+- [X] T007 [P] Create unit tests for VoiceInputState transitions, VoiceInputConfiguration defaults, and TranscriptionUpdate in Extremis/Tests/Core/VoiceInputModelsTests.swift and add to Extremis/scripts/run-tests.sh
+
+**Checkpoint**: Foundation ready — VoiceInputManager can start/stop recording, transcribe speech, and manage state. User story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 — Voice Prompt via Microphone Button (Priority: P1) MVP
+
+**Goal**: User can tap a mic button in the prompt window to speak, see transcribed text in the input field, and send it to the LLM.
+
+**Independent Test**: Open prompt window → tap mic button → speak → see transcription in input field → tap mic again to stop → press Enter to send → verify LLM responds with text.
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] Create VoiceInputIndicator SwiftUI component with mic button (idle/recording/error states), pulsing animation using DS.Animation.expandCollapse, and SF Symbols (mic/mic.fill/mic.slash) in Extremis/UI/PromptWindow/VoiceInputIndicator.swift
+- [X] T009 [US1] Add mic button to ChatInputView in the left HStack outside the supportsVision guard, wired to VoiceInputManager.shared.toggleRecording(), with live partialTranscription binding to text field in Extremis/UI/PromptWindow/ChatInputView.swift
+- [X] T010 [US1] Add mic button to PromptView (Quick Mode) in the action button area, wired to VoiceInputManager.shared.toggleRecording(), with live partialTranscription binding to instructionText in Extremis/UI/PromptWindow/PromptView.swift
+- [X] T011 [US1] Verify build succeeds and run existing test suite (cd Extremis && swift build && ./scripts/run-tests.sh) to confirm no regressions
+
+**Checkpoint**: User Story 1 is fully functional — mic button visible, voice-to-text works, text editable before send.
+
+---
+
+## Phase 4: User Story 2 — Voice Input via Keyboard Shortcut (Priority: P2)
+
+**Goal**: User can press Option+D to toggle voice recording without clicking the mic button.
+
+**Independent Test**: Open prompt window → press Option+D → speak → press Option+D → verify transcription in input field. Also test: press Option+D with window closed → verify window opens and recording starts.
+
+### Implementation for User Story 2
+
+- [X] T012 [US2] Add case voiceInput = 5 to HotkeyIdentifier enum in Extremis/Core/Services/HotkeyManager.swift
+- [X] T013 [US2] Register Option+D hotkey in setupHotkey() with callback to VoiceInputManager.shared.toggleRecording(), including logic to show prompt window if not visible, in Extremis/App/AppDelegate.swift
+- [X] T014 [US2] Verify build succeeds and run existing test suite to confirm no regressions
+
+**Checkpoint**: User Story 2 complete — Option+D toggles voice input globally.
+
+---
+
+## Phase 5: User Story 3 — Live Transcription Feedback (Priority: P2)
+
+**Goal**: Partial transcription results appear progressively in the input field while the user speaks.
+
+**Independent Test**: Start recording → speak a multi-word sentence → verify words appear progressively, not all at once after stopping.
+
+### Implementation for User Story 3
+
+- [X] T015 [US3] Ensure SpeechRecognitionService sets shouldReportPartialResults = true on SFSpeechAudioBufferRecognitionRequest and emits both partial (isFinal=false) and final (isFinal=true) TranscriptionUpdate values through the stream in Extremis/Core/Services/SpeechRecognitionService.swift
+- [X] T016 [US3] Ensure VoiceInputManager updates @Published partialTranscription on each partial result, and ChatInputView/PromptView reflect partial text in the input field with a visual distinction (e.g., lighter color or italic) for unfinalized text in Extremis/Core/Services/VoiceInputManager.swift and Extremis/UI/PromptWindow/ChatInputView.swift
+
+**Checkpoint**: User Story 3 complete — real-time streaming transcription visible while speaking.
+
+---
+
+## Phase 6: User Story 4 — Microphone Permission Handling (Priority: P3)
+
+**Goal**: System requests microphone and speech recognition permissions on first use, shows clear guidance if denied.
+
+**Independent Test**: Revoke microphone permission → tap mic button → verify error message with System Settings link appears. Grant permission → tap mic → verify recording starts.
+
+### Implementation for User Story 4
+
+- [X] T017 [US4] Add permission check flow in VoiceInputManager.startRecording(): check SFSpeechRecognizer.authorizationStatus and AVCaptureDevice.authorizationStatus, request if .notDetermined, show error with System Settings guidance if .denied, in Extremis/Core/Services/VoiceInputManager.swift
+- [X] T018 [US4] Display permission error state in VoiceInputIndicator: show mic.slash icon with tooltip containing actionable guidance ("Open System Settings > Privacy > Microphone") in Extremis/UI/PromptWindow/VoiceInputIndicator.swift
+- [X] T019 [US4] Add Siri availability check: if SFSpeechRecognizer.supportsOnDeviceRecognition is false, show guidance to enable Siri in System Settings in Extremis/Core/Services/VoiceInputManager.swift
+
+**Checkpoint**: User Story 4 complete — all permission states handled gracefully.
+
+---
+
+## Phase 7: User Story 5 — Voice Input in Chat Mode (Priority: P3)
+
+**Goal**: Voice input works for any message in an ongoing chat conversation, not just the first prompt.
+
+**Independent Test**: Start a chat → send a typed message → get response → use voice input for follow-up → verify transcribed text enters input field and sends correctly.
+
+### Implementation for User Story 5
+
+- [X] T020 [US5] Verify voice input works in active chat sessions: ensure VoiceInputManager.toggleRecording() operates independently of chat generation state, and transcribed text appends to current input field without interfering with ongoing tool execution in Extremis/UI/PromptWindow/ChatInputView.swift
+- [X] T021 [US5] Handle edge case: if recording is active when user sends a message (Enter key), stop recording first, finalize transcription, then send the combined text in Extremis/UI/PromptWindow/ChatInputView.swift
+
+**Checkpoint**: User Story 5 complete — voice input works seamlessly in multi-turn conversations.
+
+---
+
+## Phase 8: Edge Cases & Robustness
+
+**Purpose**: Handle all edge cases identified in the spec
+
+- [X] T022 Handle microphone disconnect during recording: catch AVAudioEngine errors, stop recording gracefully, retain transcribed text, show error message in Extremis/Core/Services/SpeechRecognitionService.swift
+- [X] T023 Handle app switch during recording: observe NSApplication.didResignActiveNotification to stop recording and retain text in Extremis/Core/Services/VoiceInputManager.swift
+- [X] T024 Handle silence timeout: implement configurable silence timer (default 3s) that fires when no partial results arrive, auto-stops recording in Extremis/Core/Services/VoiceInputManager.swift
+- [X] T025 Handle 60-second max duration: implement max duration timer that auto-stops recording and retains all transcribed text in Extremis/Core/Services/VoiceInputManager.swift
+- [X] T026 Handle noisy environment: ensure SpeechRecognitionService does not crash or hang on low-confidence results, always delivers whatever is transcribed in Extremis/Core/Services/SpeechRecognitionService.swift
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, final tests, and quality assurance
+
+- [X] T027 Update CLAUDE.md with voice input feature documentation: new files, key patterns, hotkey (Option+D), framework deps in /Users/shivamsaxena/Documents/Personal/Extremis/CLAUDE.md
+- [X] T028 Update README.md with voice input usage instructions and Option+D shortcut in /Users/shivamsaxena/Documents/Personal/Extremis/README.md
+- [X] T029 Run full build and test suite, verify zero regressions: cd Extremis && swift build && ./scripts/run-tests.sh
+- [ ] T030 Manual QA: test all five user stories end-to-end, verify all edge cases from spec
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **User Stories (Phase 3–7)**: All depend on Phase 2 completion
+  - US1 (Phase 3): No dependencies on other stories — **MVP**
+  - US2 (Phase 4): No dependencies on other stories (uses existing HotkeyManager)
+  - US3 (Phase 5): Refines behavior from Phase 2 (SpeechRecognitionService partial results)
+  - US4 (Phase 6): Refines behavior from Phase 2 (VoiceInputManager permission flow)
+  - US5 (Phase 7): Depends on US1 (mic button in ChatInputView must exist)
+- **Edge Cases (Phase 8)**: Depends on Phase 2; can proceed in parallel with user stories
+- **Polish (Phase 9)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Phase 2 — No dependencies on other stories
+- **US2 (P2)**: Can start after Phase 2 — No dependencies on other stories
+- **US3 (P2)**: Can start after Phase 2 — Refines SpeechRecognitionService from Phase 2
+- **US4 (P3)**: Can start after Phase 2 — Refines VoiceInputManager from Phase 2
+- **US5 (P3)**: Depends on US1 completion (mic button must exist in ChatInputView)
+
+### Within Each User Story
+
+- Models before services
+- Services before UI integration
+- Core implementation before edge cases
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel (Phase 1)
+- T006 and T007 can run in parallel with T003–T005 (Phase 2)
+- US1 and US2 can proceed in parallel after Phase 2
+- US3 and US4 can proceed in parallel after Phase 2
+- Edge case tasks (T022–T026) can proceed in parallel with each other
+
+---
+
+## Parallel Example: Phase 2
+
+```bash
+# Sequential (dependencies):
+T003 → T004 → T005  (Models → SpeechService → VoiceInputManager)
+
+# Parallel (different files):
+T006 (PermissionManager.swift)  ←→  T007 (VoiceInputModelsTests.swift)
+# Both can run alongside T003–T005
+```
+
+## Parallel Example: User Stories after Phase 2
+
+```bash
+# US1 and US2 can proceed in parallel:
+Agent 1: T008 → T009 → T010 → T011  (US1: mic button UI)
+Agent 2: T012 → T013 → T014          (US2: Option+D hotkey)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001–T002)
+2. Complete Phase 2: Foundational (T003–T007)
+3. Complete Phase 3: User Story 1 (T008–T011)
+4. **STOP and VALIDATE**: Test mic button → speak → transcription → send → LLM response
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Setup + Foundational → Core voice engine ready
+2. Add US1 (mic button) → Test → **MVP deployed**
+3. Add US2 (Option+D) + US3 (live feedback) → Test → Enhanced UX
+4. Add US4 (permissions) + US5 (chat mode) → Test → Polished experience
+5. Edge cases + polish → Production ready
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- All new test files MUST be added to scripts/run-tests.sh
+- Highest priority: zero regressions to existing functionality


### PR DESCRIPTION
## Summary

Voice input for Extremis — speak to prompt via microphone with real-time on-device speech recognition. Uses AVCaptureSession for audio capture (bypasses AVAudioEngine aggregate device bugs on macOS 26) with AVAudioEngine fallback. Voice input is automatically disabled in stealth mode to prevent the macOS mic indicator from exposing the app.

## Changes

- **SpeechRecognitionService** — AVCaptureSession + SFSpeechRecognizer wrapper with AVAudioEngine fallback. CMSampleBuffer→AVAudioPCMBuffer conversion extension. Error classification for kAFAssistantErrorDomain codes.
- **VoiceInputManager** — @MainActor singleton coordinator: start/stop/toggle recording, permission checks (mic + speech recognition), silence timer (3s), max duration timer (60s), stealth mode guard + observer.
- **VoiceInputModels** — VoiceInputState enum, TranscriptionUpdate, VoiceInputConfiguration (UserDefaults-backed), VoicePermissionStatus, SpeechRecognitionError.
- **VoiceInputIndicator** — SwiftUI mic button with recording state visualization. Disabled/slashed in stealth mode.
- **Stealth integration** — Blocks voice input start in stealth mode, auto-stops recording if stealth activated mid-recording.
- **Option+D hotkey** — Global hotkey to toggle voice recording.
- **Unit tests** — VoiceInputModelsTests (75+ assertions) and SpeechRecognitionServiceTests (58 assertions covering CMSampleBuffer conversion, error classification).
- **run-dev.sh** — Dev runner script for building .app bundle with TCC permissions.

## Related Issue

Fixes #125

## Testing

- [x] Build passes (`swift build`)
- [x] All tests pass (`./scripts/run-tests.sh`) — 39 suites, 2218 tests, 0 failures
- [x] Manual testing completed — voice input works end-to-end on macOS 26

## Checklist

- [x] Code follows project conventions
- [x] No new warnings introduced
- [x] Documentation updated (if applicable)
- [x] CLAUDE.md updated (if new patterns/features added)
