### PR TITLE
Upgrade CI runners to macos-15 for Swift 6.1+ support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       contents: write
 


### PR DESCRIPTION
MCP SDK 0.12.x requires Swift 6.1 (swift-tools-version: 6.1). macos-14 runners have Xcode 16.2 (Swift 6.0), macos-15 runners have Xcode 16.3+ (Swift 6.1).

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes made -->
-

## Related Issue

<!-- Link to related issue if applicable -->
Fixes #

## Testing

<!-- How was this tested? -->
- [ ] Build passes (`swift build`)
- [ ] All tests pass (`./scripts/run-tests.sh`)
- [ ] Manual testing completed

## Checklist

- [ ] Code follows project conventions
- [ ] No new warnings introduced
- [ ] Documentation updated (if applicable)
- [ ] CLAUDE.md updated (if new patterns/features added)
