### PR TITLE
Add stealth chat isolation with session-level tagging and memory evic…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ Feature specs are in `specs/` directory, each containing:
 - `tasks.md` - Task breakdown
 - `data-model.md` - Data model schemas (when applicable)
 
-Latest completed feature: `specs/015-voice-input/` (Voice Input via SFSpeechRecognizer)
+Latest completed feature: `specs/016-stealth-chat-isolation/` (Stealth Chat Isolation)
 
 ## Key Files
 
@@ -376,8 +376,11 @@ MCP servers are configured in `~/Library/Application Support/Extremis/mcp-server
 - UserDefaults (model selection, binary path, allowed tools) (014-claude-code-provider)
 - Swift 5.9+ + Speech framework (SFSpeechRecognizer), AVFoundation (AVCaptureSession primary, AVAudioEngine fallback), CoreMedia, Carbon (existing), ApplicationServices (existing) (015-voice-input)
 - N/A — no audio or transcription persisted; text flows into existing ChatMessage pipeline (015-voice-input)
+- Swift 5.9+ with Swift Concurrency + SwiftUI, AppKit (NSPanel), Combine, Carbon (hotkeys) (016-stealth-chat-isolation)
+- JSON files in `~/Library/Application Support/Extremis/sessions/` (existing) (016-stealth-chat-isolation)
 
 ## Recent Changes
+- 016-stealth-chat-isolation: Session-level stealth isolation. Sessions created during stealth mode are tagged `isStealth: true` (immutable). Sidebar filters stealth sessions in normal mode, shows all in stealth mode. Auto-switch away from stealth session on stealth disable. Visual lock/shield indicator on stealth sessions in sidebar. Backward-compatible Codable with `decodeIfPresent` defaulting to `false`. Quick Mode and Magic Mode already guarded in stealth. 39 new unit tests (tagging, filtering, auto-switch).
 - 015-voice-input: Voice-to-text input via Apple SFSpeechRecognizer. Uses AVCaptureSession for audio capture (bypasses AVAudioEngine aggregate device bugs on macOS 26), with AVAudioEngine fallback. CMSampleBuffer→AVAudioPCMBuffer conversion via extension. Mic button in ChatInputView and PromptView. Option+D global hotkey to toggle recording. Live partial transcription streams into text field. Silence timeout (3s configurable), max duration (60s configurable). Permission handling with actionable System Settings guidance. Stops recording on app switch, Enter key, or manual toggle. Voice input disabled in stealth mode (macOS mic indicator cannot be hidden). Text appends to existing input. UserDefaults-backed configuration.
 - 014-claude-code-provider: Claude Code CLI as an LLM provider. Uses persistent subprocess with bidirectional NDJSON via `--input-format stream-json` and `--output-format stream-json`. No API key needed. User messages sent as JSON on stdin (`{"type":"user","message":{"role":"user","content":"..."}}`). Process started eagerly, stays alive across multi-turn conversation. Auto-restart on crash. Model aliases (sonnet/opus/haiku). Configurable allowed tools. Graceful cleanup on app quit.
 - 013-stealth-mode: Stealth mode makes Extremis invisible during screen sharing. Uses NSWindow.sharingType=.none for screen capture exclusion, collectionBehavior for Mission Control hiding, process name disguise, menu bar icon hiding. Toggle via Option+Shift+S hotkey. Configurable in Preferences. Adjustable window opacity with material blur (text stays readable). Sound notifications auto-suppressed in stealth. Screenshot button captures screen behind Extremis panel via CGWindowListCreateImage. Cursor suppression via NSCursor.set() swizzle (forces arrow over panel). Window title blanked in stealth. Image expansion disabled in stealth. Tooltips removed from input bar buttons. Option+Shift+C global hotkey for screenshot capture.

--- a/Extremis/Core/Models/ChatSession.swift
+++ b/Extremis/Core/Models/ChatSession.swift
@@ -70,6 +70,12 @@ final class ChatSession: ObservableObject, Identifiable {
     /// Used to calculate which messages are "recent" (not covered by summary)
     var summaryCoversCount: Int = 0
 
+    // MARK: - Stealth Isolation
+
+    /// Whether this session was created during stealth mode
+    /// Immutable after creation — a stealth session stays stealth forever
+    let isStealth: Bool
+
     // MARK: - Tool Approval Memory (T3.8)
 
     /// Session-scoped memory for tool approvals
@@ -87,7 +93,8 @@ final class ChatSession: ObservableObject, Identifiable {
         initialRequest: String? = nil,
         maxMessages: Int = 20,
         summary: SessionSummary? = nil,
-        summaryCoversCount: Int = 0
+        summaryCoversCount: Int = 0,
+        isStealth: Bool = false
     ) {
         self.id = id
         self.originalContext = originalContext
@@ -95,6 +102,7 @@ final class ChatSession: ObservableObject, Identifiable {
         self.maxMessages = maxMessages
         self.summary = summary
         self.summaryCoversCount = summaryCoversCount
+        self.isStealth = isStealth
     }
 
     deinit {

--- a/Extremis/Core/Models/Persistence/PersistedSession.swift
+++ b/Extremis/Core/Models/Persistence/PersistedSession.swift
@@ -24,6 +24,9 @@ struct PersistedSession: Codable, Identifiable, Equatable {
     // MARK: - Summary State (P2)
     var summary: SessionSummary?        // Embedded summary for LLM context efficiency
 
+    // MARK: - Stealth Isolation
+    let isStealth: Bool                 // Whether created during stealth mode (immutable)
+
     // MARK: - Schema Version
     static let currentVersion = 1
 
@@ -39,7 +42,8 @@ struct PersistedSession: Codable, Identifiable, Equatable {
         updatedAt: Date = Date(),
         title: String? = nil,
         isArchived: Bool = false,
-        summary: SessionSummary? = nil
+        summary: SessionSummary? = nil,
+        isStealth: Bool = false
     ) {
         self.id = id
         self.version = version
@@ -51,6 +55,29 @@ struct PersistedSession: Codable, Identifiable, Equatable {
         self.title = title
         self.isArchived = isArchived
         self.summary = summary
+        self.isStealth = isStealth
+    }
+
+    // MARK: - Codable (backward compatibility for isStealth)
+
+    enum CodingKeys: String, CodingKey {
+        case id, version, messages, initialRequest, maxMessages
+        case createdAt, updatedAt, title, isArchived, summary, isStealth
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        version = try container.decodeIfPresent(Int.self, forKey: .version) ?? Self.currentVersion
+        messages = try container.decode([PersistedMessage].self, forKey: .messages)
+        initialRequest = try container.decodeIfPresent(String.self, forKey: .initialRequest)
+        maxMessages = try container.decodeIfPresent(Int.self, forKey: .maxMessages) ?? 20
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        isArchived = try container.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false
+        summary = try container.decodeIfPresent(SessionSummary.self, forKey: .summary)
+        isStealth = try container.decodeIfPresent(Bool.self, forKey: .isStealth) ?? false
     }
 
     // MARK: - Computed Properties
@@ -128,7 +155,8 @@ extension PersistedSession {
             initialRequest: session.initialRequest,
             maxMessages: session.maxMessages,
             title: nil,  // Will be auto-generated from first user message
-            summary: session.summary
+            summary: session.summary,
+            isStealth: session.isStealth
         )
     }
 
@@ -143,7 +171,8 @@ extension PersistedSession {
             initialRequest: initialRequest,
             maxMessages: maxMessages,
             summary: summary,
-            summaryCoversCount: summary?.coversMessageCount ?? 0
+            summaryCoversCount: summary?.coversMessageCount ?? 0,
+            isStealth: isStealth
         )
 
         // Restore messages with embedded context and images

--- a/Extremis/Core/Models/Persistence/SessionIndex.swift
+++ b/Extremis/Core/Models/Persistence/SessionIndex.swift
@@ -14,11 +14,12 @@ struct SessionIndexEntry: Codable, Identifiable, Equatable {
     var messageCount: Int               // Total messages (for display)
     var preview: String?                // First user message, truncated to ~100 chars
     var isArchived: Bool                // Soft-delete flag (mirrors session)
+    let isStealth: Bool                 // Whether created during stealth mode (immutable)
 
     // MARK: - Coding Keys (backward compatibility with old schema)
 
     enum CodingKeys: String, CodingKey {
-        case id, title, createdAt, updatedAt, messageCount, preview, isArchived
+        case id, title, createdAt, updatedAt, messageCount, preview, isArchived, isStealth
         // Old schema used "lastModifiedAt" instead of "updatedAt"
         case lastModifiedAt
         // Backward compatibility: old key name was "conversations"
@@ -39,6 +40,7 @@ struct SessionIndexEntry: Codable, Identifiable, Equatable {
         messageCount = try container.decode(Int.self, forKey: .messageCount)
         preview = try container.decodeIfPresent(String.self, forKey: .preview)
         isArchived = try container.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false
+        isStealth = try container.decodeIfPresent(Bool.self, forKey: .isStealth) ?? false
     }
 
     func encode(to encoder: Encoder) throws {
@@ -50,6 +52,7 @@ struct SessionIndexEntry: Codable, Identifiable, Equatable {
         try container.encode(messageCount, forKey: .messageCount)
         try container.encodeIfPresent(preview, forKey: .preview)
         try container.encode(isArchived, forKey: .isArchived)
+        try container.encode(isStealth, forKey: .isStealth)
     }
 
     // MARK: - Initialization
@@ -61,7 +64,8 @@ struct SessionIndexEntry: Codable, Identifiable, Equatable {
         updatedAt: Date,
         messageCount: Int,
         preview: String? = nil,
-        isArchived: Bool = false
+        isArchived: Bool = false,
+        isStealth: Bool = false
     ) {
         self.id = id
         self.title = title
@@ -70,6 +74,7 @@ struct SessionIndexEntry: Codable, Identifiable, Equatable {
         self.messageCount = messageCount
         self.preview = preview
         self.isArchived = isArchived
+        self.isStealth = isStealth
     }
 
     /// Create entry from a PersistedSession
@@ -81,6 +86,7 @@ struct SessionIndexEntry: Codable, Identifiable, Equatable {
         self.messageCount = session.messages.count
         self.preview = Self.generatePreview(from: session)
         self.isArchived = session.isArchived
+        self.isStealth = session.isStealth
     }
 
     // MARK: - Helpers

--- a/Extremis/Core/Services/SessionManager.swift
+++ b/Extremis/Core/Services/SessionManager.swift
@@ -32,6 +32,7 @@ final class SessionManager: ObservableObject {
     private var saveDebounceTask: Task<Void, Never>?
     private let debounceInterval: TimeInterval = 2.0
     private var cancellables = Set<AnyCancellable>()
+    private var sessionObservationCancellables = Set<AnyCancellable>()
 
     /// In-memory cache of sessions to preserve approval memory across switches
     /// Key: Session UUID, Value: ChatSession instance
@@ -48,6 +49,22 @@ final class SessionManager: ObservableObject {
     private init() {
         // Default to JSON file storage
         self.storage = JSONSessionStorage.shared
+
+        // Subscribe to stealth mode changes for auto-switch on disable (FR-006)
+        StealthManager.shared.$isStealthActive
+            .dropFirst()  // Skip initial value
+            .sink { [weak self] isActive in
+                guard let self = self else { return }
+                if !isActive {
+                    Task { @MainActor in
+                        await self.handleStealthDeactivation()
+                    }
+                }
+                // On stealth enable: no session change (FR-007)
+                // Just refresh sidebar to show/hide stealth sessions
+                self.sessionListVersion += 1
+            }
+            .store(in: &cancellables)
     }
 
     /// Initialize with custom storage (for testing or alternative backends)
@@ -68,7 +85,8 @@ final class SessionManager: ObservableObject {
 
         let session = ChatSession(
             originalContext: context,
-            initialRequest: initialRequest
+            initialRequest: initialRequest,
+            isStealth: StealthManager.shared.isStealthActive
         )
 
         let sessionId = UUID()
@@ -103,6 +121,12 @@ final class SessionManager: ObservableObject {
             // Load the session
             guard let persisted = try await storage.loadSession(id: activeId) else {
                 print("[SessionManager] Active session \(activeId) not found in storage")
+                return
+            }
+
+            // Don't restore a stealth session in normal mode
+            if persisted.isStealth && !StealthManager.shared.isStealthActive {
+                print("[SessionManager] Skipping restore — stealth session \(activeId) in normal mode")
                 return
             }
 
@@ -312,8 +336,8 @@ final class SessionManager: ObservableObject {
     // MARK: - Session Observation
 
     private func observeSession(_ session: ChatSession) {
-        // Cancel previous subscriptions
-        cancellables.removeAll()
+        // Cancel previous session-specific subscriptions (preserves stealth subscription)
+        sessionObservationCancellables.removeAll()
 
         // Observe message changes
         session.$messages
@@ -321,7 +345,7 @@ final class SessionManager: ObservableObject {
             .sink { [weak self] _ in
                 self?.markDirty()
             }
-            .store(in: &cancellables)
+            .store(in: &sessionObservationCancellables)
     }
 
     // MARK: - Clear Session
@@ -336,7 +360,7 @@ final class SessionManager: ObservableObject {
         currentSessionId = nil
         isDirty = false
         hasDraftSession = false
-        cancellables.removeAll()
+        sessionObservationCancellables.removeAll()
 
         // Clear active session in index
         do {
@@ -401,7 +425,7 @@ final class SessionManager: ObservableObject {
             currentSessionId = nil
             isDirty = false
             hasDraftSession = false
-            cancellables.removeAll()
+            sessionObservationCancellables.removeAll()
         }
 
         // Remove from cache
@@ -410,6 +434,54 @@ final class SessionManager: ObservableObject {
         try await storage.deleteSession(id: id)
         sessionListVersion += 1  // Notify sidebar to refresh
         print("[SessionManager] Deleted session \(id)")
+    }
+
+    // MARK: - Stealth Isolation
+
+    /// Handle stealth mode deactivation: switch away from stealth sessions (FR-006)
+    private func handleStealthDeactivation() async {
+        // Always evict stealth sessions from in-memory cache
+        let stealthKeys = sessionCache.filter { $0.value.isStealth }.map { $0.key }
+        for key in stealthKeys {
+            sessionCache.removeValue(forKey: key)
+        }
+        if !stealthKeys.isEmpty {
+            print("[SessionManager] Evicted \(stealthKeys.count) stealth session(s) from cache")
+        }
+
+        // If current session is not stealth, no switch needed
+        guard let session = currentSession, session.isStealth else { return }
+
+        print("[SessionManager] Stealth deactivated — switching away from stealth session")
+
+        // Save current stealth session before switching
+        await saveIfDirty()
+
+        // Find most recent normal (non-stealth, non-archived) session
+        do {
+            let allSessions = try await storage.listSessions()
+            let normalSessions = allSessions
+                .filter { !$0.isStealth && !$0.isArchived }
+                .sorted { $0.updatedAt > $1.updatedAt }
+
+            if let mostRecent = normalSessions.first {
+                try await loadSession(id: mostRecent.id)
+                print("[SessionManager] Switched to normal session \(mostRecent.id)")
+            } else {
+                // No normal sessions — clear active session
+                currentSession = nil
+                currentSessionId = nil
+                hasDraftSession = false
+                try await storage.setActiveSessionId(nil)
+                print("[SessionManager] No normal sessions — cleared active session")
+            }
+        } catch {
+            print("[SessionManager] Error during stealth deactivation switch: \(error)")
+            // Fallback: clear active session to prevent stealth content showing
+            currentSession = nil
+            currentSessionId = nil
+            hasDraftSession = false
+        }
     }
 
     // MARK: - Session Cache

--- a/Extremis/Tests/Core/StealthAutoSwitchTests.swift
+++ b/Extremis/Tests/Core/StealthAutoSwitchTests.swift
@@ -1,0 +1,241 @@
+// MARK: - Stealth Auto-Switch Tests
+// Tests for automatic session switching when stealth mode is deactivated
+
+import Foundation
+
+// MARK: - Test Runner Framework
+
+struct TestRunner {
+    static var passedCount = 0
+    static var failedCount = 0
+    static var failedTests: [(name: String, message: String)] = []
+    static var currentGroup = ""
+
+    static func reset() {
+        passedCount = 0
+        failedCount = 0
+        failedTests = []
+        currentGroup = ""
+    }
+
+    static func setGroup(_ name: String) {
+        currentGroup = name
+        print("")
+        print("📦 \(name)")
+        print("----------------------------------------")
+    }
+
+    static func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ testName: String) {
+        if actual == expected {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            let message = "Expected '\(expected)' but got '\(actual)'"
+            failedTests.append((testName, message))
+            print("  ✗ \(testName): \(message)")
+        }
+    }
+
+    static func assertNil<T>(_ value: T?, _ testName: String) {
+        if value == nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            let message = "Expected nil but got value"
+            failedTests.append((testName, message))
+            print("  ✗ \(testName): \(message)")
+        }
+    }
+
+    static func assertNotNil<T>(_ value: T?, _ testName: String) {
+        if value != nil {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected non-nil but got nil"))
+            print("  ✗ \(testName): Expected non-nil but got nil")
+        }
+    }
+
+    static func assertTrue(_ condition: Bool, _ testName: String) {
+        if condition {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected true but got false"))
+            print("  ✗ \(testName): Expected true but got false")
+        }
+    }
+
+    static func assertFalse(_ condition: Bool, _ testName: String) {
+        assertTrue(!condition, testName)
+    }
+
+    static func printSummary() {
+        print("")
+        print("==================================================")
+        print("TEST SUMMARY")
+        print("==================================================")
+        print("Passed: \(passedCount)")
+        print("Failed: \(failedCount)")
+        print("Total:  \(passedCount + failedCount)")
+        if !failedTests.isEmpty {
+            print("")
+            print("Failed tests:")
+            for (name, message) in failedTests {
+                print("  - \(name): \(message)")
+            }
+        }
+        print("==================================================")
+    }
+}
+
+// MARK: - Lightweight Entry for Testing
+
+struct SwitchTestEntry {
+    let id: UUID
+    let title: String
+    let isStealth: Bool
+    let isArchived: Bool
+    let updatedAt: Date
+
+    init(title: String, isStealth: Bool = false, isArchived: Bool = false, minutesAgo: Int = 0) {
+        self.id = UUID()
+        self.title = title
+        self.isStealth = isStealth
+        self.isArchived = isArchived
+        self.updatedAt = Date().addingTimeInterval(TimeInterval(-minutesAgo * 60))
+    }
+}
+
+// MARK: - Auto-Switch Logic (mirrors the actual implementation)
+
+/// Determine which session to switch to when stealth is deactivated
+/// Returns the ID of the session to switch to, or nil if no switch is needed
+func determineSessionAfterStealthDisable(
+    currentSessionIsStealth: Bool,
+    sessions: [SwitchTestEntry]
+) -> UUID? {
+    // If current session is not stealth, no switch needed
+    guard currentSessionIsStealth else { return nil }
+
+    // Find the most recent non-stealth, non-archived session
+    let normalSessions = sessions
+        .filter { !$0.isStealth && !$0.isArchived }
+        .sorted { $0.updatedAt > $1.updatedAt }
+
+    return normalSessions.first?.id
+}
+
+// MARK: - Tests
+
+func testStealthDisableWithStealthSession() {
+    TestRunner.setGroup("Stealth disable — active stealth session switches to most recent normal")
+
+    let normal1 = SwitchTestEntry(title: "Normal Old", minutesAgo: 10)
+    let normal2 = SwitchTestEntry(title: "Normal Recent", minutesAgo: 1)
+    let stealth1 = SwitchTestEntry(title: "Stealth", isStealth: true, minutesAgo: 5)
+
+    let sessions = [normal1, normal2, stealth1]
+    let switchTo = determineSessionAfterStealthDisable(
+        currentSessionIsStealth: true,
+        sessions: sessions
+    )
+
+    TestRunner.assertNotNil(switchTo, "Should switch to a session")
+    TestRunner.assertEqual(switchTo, normal2.id, "Switches to most recent normal session")
+}
+
+func testStealthDisableWithNormalSession() {
+    TestRunner.setGroup("Stealth disable — active normal session stays (no switch)")
+
+    let normal1 = SwitchTestEntry(title: "Normal")
+    let stealth1 = SwitchTestEntry(title: "Stealth", isStealth: true)
+
+    let sessions = [normal1, stealth1]
+    let switchTo = determineSessionAfterStealthDisable(
+        currentSessionIsStealth: false,
+        sessions: sessions
+    )
+
+    TestRunner.assertNil(switchTo, "No switch needed — current is normal")
+}
+
+func testStealthDisableNoNormalSessions() {
+    TestRunner.setGroup("Stealth disable — no normal sessions available (clear)")
+
+    let stealth1 = SwitchTestEntry(title: "Stealth 1", isStealth: true)
+    let stealth2 = SwitchTestEntry(title: "Stealth 2", isStealth: true)
+
+    let sessions = [stealth1, stealth2]
+    let switchTo = determineSessionAfterStealthDisable(
+        currentSessionIsStealth: true,
+        sessions: sessions
+    )
+
+    TestRunner.assertNil(switchTo, "No normal sessions — returns nil (clear active)")
+}
+
+func testStealthDisableIgnoresArchived() {
+    TestRunner.setGroup("Stealth disable — ignores archived normal sessions")
+
+    let archived = SwitchTestEntry(title: "Normal Archived", isArchived: true, minutesAgo: 1)
+    let stealth1 = SwitchTestEntry(title: "Stealth", isStealth: true)
+
+    let sessions = [archived, stealth1]
+    let switchTo = determineSessionAfterStealthDisable(
+        currentSessionIsStealth: true,
+        sessions: sessions
+    )
+
+    TestRunner.assertNil(switchTo, "Archived normal session not eligible — returns nil")
+}
+
+func testStealthEnableNoSwitch() {
+    TestRunner.setGroup("Stealth enable — no session change")
+
+    // Stealth enable should never trigger a switch
+    // The current session stays as-is (FR-007)
+    let normal1 = SwitchTestEntry(title: "Normal")
+    let sessions = [normal1]
+
+    // We test this by verifying the function returns nil when currentSession is NOT stealth
+    // (because on enable, the current session is always a normal one)
+    let switchTo = determineSessionAfterStealthDisable(
+        currentSessionIsStealth: false,
+        sessions: sessions
+    )
+
+    TestRunner.assertNil(switchTo, "Stealth enable: no switch (current stays)")
+}
+
+func testStealthDisableEmptySessionList() {
+    TestRunner.setGroup("Stealth disable — empty session list")
+
+    let switchTo = determineSessionAfterStealthDisable(
+        currentSessionIsStealth: true,
+        sessions: []
+    )
+
+    TestRunner.assertNil(switchTo, "Empty list — returns nil (clear active)")
+}
+
+// MARK: - Entry Point
+
+@main
+struct StealthAutoSwitchTests {
+    static func main() {
+        testStealthDisableWithStealthSession()
+        testStealthDisableWithNormalSession()
+        testStealthDisableNoNormalSessions()
+        testStealthDisableIgnoresArchived()
+        testStealthEnableNoSwitch()
+        testStealthDisableEmptySessionList()
+        TestRunner.printSummary()
+        if TestRunner.failedCount > 0 { exit(1) }
+    }
+}

--- a/Extremis/Tests/Core/StealthSessionFilteringTests.swift
+++ b/Extremis/Tests/Core/StealthSessionFilteringTests.swift
@@ -1,0 +1,213 @@
+// MARK: - Stealth Session Filtering Tests
+// Tests for session visibility filtering based on stealth mode state
+
+import Foundation
+
+// MARK: - Test Runner Framework
+
+struct TestRunner {
+    static var passedCount = 0
+    static var failedCount = 0
+    static var failedTests: [(name: String, message: String)] = []
+    static var currentGroup = ""
+
+    static func reset() {
+        passedCount = 0
+        failedCount = 0
+        failedTests = []
+        currentGroup = ""
+    }
+
+    static func setGroup(_ name: String) {
+        currentGroup = name
+        print("")
+        print("📦 \(name)")
+        print("----------------------------------------")
+    }
+
+    static func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ testName: String) {
+        if actual == expected {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            let message = "Expected '\(expected)' but got '\(actual)'"
+            failedTests.append((testName, message))
+            print("  ✗ \(testName): \(message)")
+        }
+    }
+
+    static func assertTrue(_ condition: Bool, _ testName: String) {
+        if condition {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected true but got false"))
+            print("  ✗ \(testName): Expected true but got false")
+        }
+    }
+
+    static func assertFalse(_ condition: Bool, _ testName: String) {
+        assertTrue(!condition, testName)
+    }
+
+    static func printSummary() {
+        print("")
+        print("==================================================")
+        print("TEST SUMMARY")
+        print("==================================================")
+        print("Passed: \(passedCount)")
+        print("Failed: \(failedCount)")
+        print("Total:  \(passedCount + failedCount)")
+        if !failedTests.isEmpty {
+            print("")
+            print("Failed tests:")
+            for (name, message) in failedTests {
+                print("  - \(name): \(message)")
+            }
+        }
+        print("==================================================")
+    }
+}
+
+// MARK: - Lightweight Session Entry for Testing
+
+struct FilterTestEntry: Equatable {
+    let id: UUID
+    let title: String
+    let isStealth: Bool
+    let isArchived: Bool
+    let updatedAt: Date
+
+    init(title: String, isStealth: Bool = false, isArchived: Bool = false, updatedAt: Date = Date()) {
+        self.id = UUID()
+        self.title = title
+        self.isStealth = isStealth
+        self.isArchived = isArchived
+        self.updatedAt = updatedAt
+    }
+}
+
+// MARK: - Filtering Logic (mirrors the actual implementation)
+
+/// Filter sessions for visibility based on stealth mode state
+/// This is the pure function extracted from the sidebar view for testability
+func visibleSessions(sessions: [FilterTestEntry], isStealthActive: Bool) -> [FilterTestEntry] {
+    let active = sessions.filter { !$0.isArchived }
+    if isStealthActive {
+        return active  // Show all (stealth + normal)
+    } else {
+        return active.filter { !$0.isStealth }  // Hide stealth sessions
+    }
+}
+
+// MARK: - Tests
+
+func testFilterStealthActiveShowsAll() {
+    TestRunner.setGroup("Stealth active — shows all sessions")
+
+    let sessions = [
+        FilterTestEntry(title: "Normal 1"),
+        FilterTestEntry(title: "Stealth 1", isStealth: true),
+        FilterTestEntry(title: "Normal 2"),
+        FilterTestEntry(title: "Stealth 2", isStealth: true),
+    ]
+
+    let result = visibleSessions(sessions: sessions, isStealthActive: true)
+    TestRunner.assertEqual(result.count, 4, "Stealth active: all 4 sessions visible")
+    TestRunner.assertTrue(result.contains { $0.title == "Stealth 1" }, "Stealth 1 visible")
+    TestRunner.assertTrue(result.contains { $0.title == "Stealth 2" }, "Stealth 2 visible")
+    TestRunner.assertTrue(result.contains { $0.title == "Normal 1" }, "Normal 1 visible")
+    TestRunner.assertTrue(result.contains { $0.title == "Normal 2" }, "Normal 2 visible")
+}
+
+func testFilterStealthInactiveHidesStealth() {
+    TestRunner.setGroup("Stealth inactive — hides stealth sessions")
+
+    let sessions = [
+        FilterTestEntry(title: "Normal 1"),
+        FilterTestEntry(title: "Stealth 1", isStealth: true),
+        FilterTestEntry(title: "Normal 2"),
+        FilterTestEntry(title: "Stealth 2", isStealth: true),
+    ]
+
+    let result = visibleSessions(sessions: sessions, isStealthActive: false)
+    TestRunner.assertEqual(result.count, 2, "Stealth inactive: only 2 normal sessions visible")
+    TestRunner.assertTrue(result.contains { $0.title == "Normal 1" }, "Normal 1 visible")
+    TestRunner.assertTrue(result.contains { $0.title == "Normal 2" }, "Normal 2 visible")
+    TestRunner.assertFalse(result.contains { $0.title == "Stealth 1" }, "Stealth 1 hidden")
+    TestRunner.assertFalse(result.contains { $0.title == "Stealth 2" }, "Stealth 2 hidden")
+}
+
+func testFilterNoStealthSessions() {
+    TestRunner.setGroup("No stealth sessions — same in both modes")
+
+    let sessions = [
+        FilterTestEntry(title: "Normal 1"),
+        FilterTestEntry(title: "Normal 2"),
+        FilterTestEntry(title: "Normal 3"),
+    ]
+
+    let stealthOn = visibleSessions(sessions: sessions, isStealthActive: true)
+    let stealthOff = visibleSessions(sessions: sessions, isStealthActive: false)
+    TestRunner.assertEqual(stealthOn.count, 3, "Stealth on: all 3 normal sessions")
+    TestRunner.assertEqual(stealthOff.count, 3, "Stealth off: all 3 normal sessions")
+}
+
+func testFilterAllStealthSessions() {
+    TestRunner.setGroup("All stealth sessions — empty in normal mode")
+
+    let sessions = [
+        FilterTestEntry(title: "Stealth 1", isStealth: true),
+        FilterTestEntry(title: "Stealth 2", isStealth: true),
+    ]
+
+    let stealthOn = visibleSessions(sessions: sessions, isStealthActive: true)
+    let stealthOff = visibleSessions(sessions: sessions, isStealthActive: false)
+    TestRunner.assertEqual(stealthOn.count, 2, "Stealth on: both stealth sessions visible")
+    TestRunner.assertEqual(stealthOff.count, 0, "Stealth off: empty list")
+}
+
+func testFilterExcludesArchived() {
+    TestRunner.setGroup("Archived sessions excluded in both modes")
+
+    let sessions = [
+        FilterTestEntry(title: "Normal Active"),
+        FilterTestEntry(title: "Stealth Active", isStealth: true),
+        FilterTestEntry(title: "Normal Archived", isArchived: true),
+        FilterTestEntry(title: "Stealth Archived", isStealth: true, isArchived: true),
+    ]
+
+    let stealthOn = visibleSessions(sessions: sessions, isStealthActive: true)
+    let stealthOff = visibleSessions(sessions: sessions, isStealthActive: false)
+    TestRunner.assertEqual(stealthOn.count, 2, "Stealth on: 2 active sessions (archived excluded)")
+    TestRunner.assertEqual(stealthOff.count, 1, "Stealth off: 1 normal active session")
+    TestRunner.assertTrue(stealthOff.first?.title == "Normal Active", "Only normal active visible")
+}
+
+func testFilterEmptyList() {
+    TestRunner.setGroup("Empty session list")
+
+    let sessions: [FilterTestEntry] = []
+    let stealthOn = visibleSessions(sessions: sessions, isStealthActive: true)
+    let stealthOff = visibleSessions(sessions: sessions, isStealthActive: false)
+    TestRunner.assertEqual(stealthOn.count, 0, "Stealth on: empty")
+    TestRunner.assertEqual(stealthOff.count, 0, "Stealth off: empty")
+}
+
+// MARK: - Entry Point
+
+@main
+struct StealthSessionFilteringTests {
+    static func main() {
+        testFilterStealthActiveShowsAll()
+        testFilterStealthInactiveHidesStealth()
+        testFilterNoStealthSessions()
+        testFilterAllStealthSessions()
+        testFilterExcludesArchived()
+        testFilterEmptyList()
+        TestRunner.printSummary()
+        if TestRunner.failedCount > 0 { exit(1) }
+    }
+}

--- a/Extremis/Tests/Core/StealthSessionTaggingTests.swift
+++ b/Extremis/Tests/Core/StealthSessionTaggingTests.swift
@@ -1,0 +1,356 @@
+// MARK: - Stealth Session Tagging Tests
+// Tests for isStealth property on ChatSession, PersistedSession, and SessionIndexEntry
+// Covers creation, backward compatibility, and round-trip persistence
+
+import Foundation
+
+// MARK: - Test Runner Framework
+
+struct TestRunner {
+    static var passedCount = 0
+    static var failedCount = 0
+    static var failedTests: [(name: String, message: String)] = []
+    static var currentGroup = ""
+
+    static func reset() {
+        passedCount = 0
+        failedCount = 0
+        failedTests = []
+        currentGroup = ""
+    }
+
+    static func setGroup(_ name: String) {
+        currentGroup = name
+        print("")
+        print("📦 \(name)")
+        print("----------------------------------------")
+    }
+
+    static func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ testName: String) {
+        if actual == expected {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            let message = "Expected '\(expected)' but got '\(actual)'"
+            failedTests.append((testName, message))
+            print("  ✗ \(testName): \(message)")
+        }
+    }
+
+    static func assertTrue(_ condition: Bool, _ testName: String) {
+        if condition {
+            passedCount += 1
+            print("  ✓ \(testName)")
+        } else {
+            failedCount += 1
+            failedTests.append((testName, "Expected true but got false"))
+            print("  ✗ \(testName): Expected true but got false")
+        }
+    }
+
+    static func assertFalse(_ condition: Bool, _ testName: String) {
+        assertTrue(!condition, testName)
+    }
+
+    static func printSummary() {
+        print("")
+        print("==================================================")
+        print("TEST SUMMARY")
+        print("==================================================")
+        print("Passed: \(passedCount)")
+        print("Failed: \(failedCount)")
+        print("Total:  \(passedCount + failedCount)")
+        if !failedTests.isEmpty {
+            print("")
+            print("Failed tests:")
+            for (name, message) in failedTests {
+                print("  - \(name): \(message)")
+            }
+        }
+        print("==================================================")
+    }
+}
+
+// MARK: - Minimal Codable Models for Testing
+// Replicate just the Codable parts needed to test isStealth without importing the full app
+
+struct TestPersistedSession: Codable, Equatable {
+    let id: UUID
+    let version: Int
+    var messages: [TestPersistedMessage]
+    let initialRequest: String?
+    let maxMessages: Int
+    let createdAt: Date
+    var updatedAt: Date
+    var title: String?
+    var isArchived: Bool
+    let isStealth: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id, version, messages, initialRequest, maxMessages
+        case createdAt, updatedAt, title, isArchived, isStealth
+    }
+
+    init(
+        id: UUID = UUID(),
+        version: Int = 1,
+        messages: [TestPersistedMessage] = [],
+        initialRequest: String? = nil,
+        maxMessages: Int = 20,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        title: String? = nil,
+        isArchived: Bool = false,
+        isStealth: Bool = false
+    ) {
+        self.id = id
+        self.version = version
+        self.messages = messages
+        self.initialRequest = initialRequest
+        self.maxMessages = maxMessages
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.title = title
+        self.isArchived = isArchived
+        self.isStealth = isStealth
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        version = try container.decodeIfPresent(Int.self, forKey: .version) ?? 1
+        messages = try container.decode([TestPersistedMessage].self, forKey: .messages)
+        initialRequest = try container.decodeIfPresent(String.self, forKey: .initialRequest)
+        maxMessages = try container.decodeIfPresent(Int.self, forKey: .maxMessages) ?? 20
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        isArchived = try container.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false
+        isStealth = try container.decodeIfPresent(Bool.self, forKey: .isStealth) ?? false
+    }
+}
+
+struct TestPersistedMessage: Codable, Equatable {
+    let id: UUID
+    let role: String
+    let content: String
+    let timestamp: Date
+}
+
+struct TestSessionIndexEntry: Codable, Equatable {
+    let id: UUID
+    var title: String
+    let createdAt: Date
+    var updatedAt: Date
+    var messageCount: Int
+    var preview: String?
+    var isArchived: Bool
+    let isStealth: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, createdAt, updatedAt, messageCount, preview, isArchived, isStealth
+        case lastModifiedAt
+    }
+
+    init(
+        id: UUID = UUID(),
+        title: String = "Test",
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        messageCount: Int = 0,
+        preview: String? = nil,
+        isArchived: Bool = false,
+        isStealth: Bool = false
+    ) {
+        self.id = id
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messageCount = messageCount
+        self.preview = preview
+        self.isArchived = isArchived
+        self.isStealth = isStealth
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        title = try container.decode(String.self, forKey: .title)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        if let updated = try? container.decode(Date.self, forKey: .updatedAt) {
+            updatedAt = updated
+        } else {
+            updatedAt = try container.decode(Date.self, forKey: .lastModifiedAt)
+        }
+        messageCount = try container.decode(Int.self, forKey: .messageCount)
+        preview = try container.decodeIfPresent(String.self, forKey: .preview)
+        isArchived = try container.decodeIfPresent(Bool.self, forKey: .isArchived) ?? false
+        isStealth = try container.decodeIfPresent(Bool.self, forKey: .isStealth) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encode(messageCount, forKey: .messageCount)
+        try container.encodeIfPresent(preview, forKey: .preview)
+        try container.encode(isArchived, forKey: .isArchived)
+        try container.encode(isStealth, forKey: .isStealth)
+    }
+}
+
+// MARK: - Tests
+
+func testPersistedSessionStealthFlag() {
+    TestRunner.setGroup("PersistedSession isStealth")
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    // Test: default is false
+    let normalSession = TestPersistedSession()
+    TestRunner.assertFalse(normalSession.isStealth, "Default isStealth is false")
+
+    // Test: explicit true
+    let stealthSession = TestPersistedSession(isStealth: true)
+    TestRunner.assertTrue(stealthSession.isStealth, "Explicit isStealth true")
+
+    // Test: round-trip with isStealth true
+    do {
+        let data = try encoder.encode(stealthSession)
+        let decoded = try decoder.decode(TestPersistedSession.self, from: data)
+        TestRunner.assertTrue(decoded.isStealth, "Round-trip preserves isStealth true")
+    } catch {
+        TestRunner.assertTrue(false, "Round-trip encode/decode should not throw: \(error)")
+    }
+
+    // Test: round-trip with isStealth false
+    do {
+        let data = try encoder.encode(normalSession)
+        let decoded = try decoder.decode(TestPersistedSession.self, from: data)
+        TestRunner.assertFalse(decoded.isStealth, "Round-trip preserves isStealth false")
+    } catch {
+        TestRunner.assertTrue(false, "Round-trip encode/decode should not throw: \(error)")
+    }
+}
+
+func testPersistedSessionBackwardCompat() {
+    TestRunner.setGroup("PersistedSession backward compatibility")
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    // JSON without isStealth field (simulates old session files)
+    let jsonWithoutStealth = """
+    {
+        "id": "550E8400-E29B-41D4-A716-446655440000",
+        "version": 1,
+        "messages": [],
+        "maxMessages": 20,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "isArchived": false
+    }
+    """.data(using: .utf8)!
+
+    do {
+        let decoded = try decoder.decode(TestPersistedSession.self, from: jsonWithoutStealth)
+        TestRunner.assertFalse(decoded.isStealth, "Missing isStealth defaults to false")
+        TestRunner.assertEqual(decoded.id.uuidString, "550E8400-E29B-41D4-A716-446655440000", "ID preserved")
+    } catch {
+        TestRunner.assertTrue(false, "Decoding old JSON without isStealth should not throw: \(error)")
+    }
+
+    // JSON with isStealth: true
+    let jsonWithStealth = """
+    {
+        "id": "550E8400-E29B-41D4-A716-446655440001",
+        "version": 1,
+        "messages": [],
+        "maxMessages": 20,
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "isArchived": false,
+        "isStealth": true
+    }
+    """.data(using: .utf8)!
+
+    do {
+        let decoded = try decoder.decode(TestPersistedSession.self, from: jsonWithStealth)
+        TestRunner.assertTrue(decoded.isStealth, "Explicit isStealth true decoded correctly")
+    } catch {
+        TestRunner.assertTrue(false, "Decoding JSON with isStealth should not throw: \(error)")
+    }
+}
+
+func testSessionIndexEntryStealthFlag() {
+    TestRunner.setGroup("SessionIndexEntry isStealth")
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    // Test: default is false
+    let normalEntry = TestSessionIndexEntry()
+    TestRunner.assertFalse(normalEntry.isStealth, "Default isStealth is false")
+
+    // Test: explicit true
+    let stealthEntry = TestSessionIndexEntry(isStealth: true)
+    TestRunner.assertTrue(stealthEntry.isStealth, "Explicit isStealth true")
+
+    // Test: round-trip
+    do {
+        let data = try encoder.encode(stealthEntry)
+        let decoded = try decoder.decode(TestSessionIndexEntry.self, from: data)
+        TestRunner.assertTrue(decoded.isStealth, "Round-trip preserves isStealth true")
+    } catch {
+        TestRunner.assertTrue(false, "Round-trip should not throw: \(error)")
+    }
+}
+
+func testSessionIndexEntryBackwardCompat() {
+    TestRunner.setGroup("SessionIndexEntry backward compatibility")
+
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    // JSON without isStealth field (simulates old index entries)
+    let jsonWithoutStealth = """
+    {
+        "id": "550E8400-E29B-41D4-A716-446655440002",
+        "title": "Old Session",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "messageCount": 5
+    }
+    """.data(using: .utf8)!
+
+    do {
+        let decoded = try decoder.decode(TestSessionIndexEntry.self, from: jsonWithoutStealth)
+        TestRunner.assertFalse(decoded.isStealth, "Missing isStealth defaults to false")
+        TestRunner.assertEqual(decoded.title, "Old Session", "Title preserved")
+        TestRunner.assertFalse(decoded.isArchived, "Missing isArchived defaults to false")
+    } catch {
+        TestRunner.assertTrue(false, "Decoding old JSON without isStealth should not throw: \(error)")
+    }
+}
+
+// MARK: - Entry Point
+
+@main
+struct StealthSessionTaggingTests {
+    static func main() {
+        testPersistedSessionStealthFlag()
+        testPersistedSessionBackwardCompat()
+        testSessionIndexEntryStealthFlag()
+        testSessionIndexEntryBackwardCompat()
+        TestRunner.printSummary()
+        if TestRunner.failedCount > 0 { exit(1) }
+    }
+}

--- a/Extremis/UI/PromptWindow/PromptWindowController.swift
+++ b/Extremis/UI/PromptWindow/PromptWindowController.swift
@@ -114,6 +114,9 @@ final class PromptWindowController: NSWindowController {
     /// Stealth mode observer
     private var stealthCancellable: AnyCancellable?
 
+    /// Session switch observer (syncs view model when SessionManager switches session externally)
+    private var sessionSwitchCancellable: AnyCancellable?
+
     // MARK: - Tool Approval State (T3.14)
 
     /// Represents a queued approval batch waiting to be processed
@@ -189,6 +192,27 @@ final class PromptWindowController: NSWindowController {
                     stealthPanel?.stealthActive = isActive
                 }
         }
+
+        // Observe external session switches (e.g., stealth deactivation auto-switch)
+        // Syncs view model when SessionManager changes the active session from outside the controller
+        sessionSwitchCancellable = SessionManager.shared.$currentSessionId
+            .dropFirst()  // Skip initial value
+            .sink { [weak self] newSessionId in
+                guard let self = self else { return }
+                let vmSessionId = self.viewModel.sessionId
+
+                // Only sync if the session actually changed externally
+                if newSessionId != vmSessionId {
+                    if let session = SessionManager.shared.currentSession, let id = newSessionId {
+                        self.viewModel.setRestoredSession(session, id: id)
+                        print("📋 PromptWindow: Synced external session switch to \(id)")
+                    } else if newSessionId == nil {
+                        // Session was cleared (e.g., stealth deactivation with no normal sessions)
+                        self.viewModel.reset()
+                        print("📋 PromptWindow: Session cleared by external switch")
+                    }
+                }
+            }
 
         updateContentView()
         panel.center()
@@ -747,8 +771,12 @@ final class PromptViewModel: ObservableObject {
     /// Badge is shown only for explicit user actions (New Session button, Chat Mode start)
     private func ensureSession(context: Context?, instruction: String?) {
         if session == nil {
-            // Create a new session
-            let sess = ChatSession(originalContext: context, initialRequest: instruction)
+            // Create a new session (inherit stealth state from current mode)
+            let sess = ChatSession(
+                originalContext: context,
+                initialRequest: instruction,
+                isStealth: StealthManager.shared.isStealthActive
+            )
             session = sess
             sessionId = UUID()
 
@@ -1023,7 +1051,11 @@ final class PromptViewModel: ObservableObject {
         }
 
         // Legacy path: Create session with initial exchange (for edge cases)
-        let sess = ChatSession(originalContext: currentContext, initialRequest: instructionText)
+        let sess = ChatSession(
+            originalContext: currentContext,
+            initialRequest: instructionText,
+            isStealth: StealthManager.shared.isStealthActive
+        )
 
         // Add the initial user message (instruction or summarize request)
         let userContent = isSummarizing ? "Summarize this text" : instructionText
@@ -1056,7 +1088,11 @@ final class PromptViewModel: ObservableObject {
 
         // If no session exists, create one for the chat
         if session == nil {
-            let sess = ChatSession(originalContext: currentContext, initialRequest: messageText)
+            let sess = ChatSession(
+                originalContext: currentContext,
+                initialRequest: messageText,
+                isStealth: StealthManager.shared.isStealthActive
+            )
             session = sess
             sessionId = UUID()
 
@@ -1130,7 +1166,11 @@ final class PromptViewModel: ObservableObject {
 
         // If no session exists, create one for the command execution
         if session == nil {
-            let sess = ChatSession(originalContext: currentContext, initialRequest: messageText)
+            let sess = ChatSession(
+                originalContext: currentContext,
+                initialRequest: messageText,
+                isStealth: StealthManager.shared.isStealthActive
+            )
             session = sess
             sessionId = UUID()
 
@@ -1637,6 +1677,21 @@ struct PromptContainerView: View {
                     // New session indicator badge - tied to draft session state
                     // Shows when session exists but has no messages yet
                     NewSessionBadge(isVisible: .constant(sessionManager.hasDraftSession))
+
+                    // Session-level stealth indicator
+                    if viewModel.session?.isStealth == true {
+                        HStack(spacing: 4) {
+                            Image(systemName: "lock.shield.fill")
+                                .font(.system(size: 10))
+                            Text("Stealth Session")
+                                .font(.system(size: 10, weight: .medium))
+                        }
+                        .foregroundColor(DS.Colors.textSecondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(DS.Colors.textSecondary.opacity(0.1))
+                        .continuousCornerRadius(DS.Radii.small)
+                    }
 
                     Spacer()
 

--- a/Extremis/UI/PromptWindow/SessionListView.swift
+++ b/Extremis/UI/PromptWindow/SessionListView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// Sidebar view showing list of sessions
 struct SessionListView: View {
     @ObservedObject var sessionManager: SessionManager
+    @ObservedObject var stealthManager = StealthManager.shared
     let onSelectSession: (UUID) -> Void
     let onNewSession: () -> Void
     let onDeleteSession: (UUID) -> Void
@@ -13,6 +14,15 @@ struct SessionListView: View {
     @State private var sessions: [SessionIndexEntry] = []
     @State private var isLoading = false
     @State private var errorMessage: String?
+
+    /// Visible sessions filtered by stealth mode state
+    private var visibleSessions: [SessionIndexEntry] {
+        if stealthManager.isStealthActive {
+            return sessions  // Stealth mode: show all sessions
+        } else {
+            return sessions.filter { !$0.isStealth }  // Normal mode: hide stealth sessions
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -36,7 +46,7 @@ struct SessionListView: View {
                 ProgressView()
                     .scaleEffect(0.8)
                 Spacer()
-            } else if sessions.isEmpty && !sessionManager.hasDraftSession {
+            } else if visibleSessions.isEmpty && !sessionManager.hasDraftSession {
                 // Show empty state only if no draft AND no saved sessions
                 Spacer()
                 VStack(spacing: 8) {
@@ -65,13 +75,14 @@ struct SessionListView: View {
                         .transition(.opacity)
                     }
 
-                    // Persisted sessions
-                    ForEach(sessions) { entry in
+                    // Persisted sessions (filtered by stealth mode)
+                    ForEach(visibleSessions) { entry in
                         SessionRowView(
                             entry: entry,
                             // Not active if we have a draft (draft takes precedence)
                             isActive: !sessionManager.hasDraftSession && entry.id == sessionManager.currentSessionId,
                             isDisabled: sessionManager.isAnySessionGenerating && entry.id != sessionManager.generatingSessionId,
+                            isStealthSession: entry.isStealth,
                             onSelect: { onSelectSession(entry.id) },
                             onDelete: { onDeleteSession(entry.id) }
                         )
@@ -107,6 +118,10 @@ struct SessionListView: View {
         }
         .onChange(of: sessionManager.hasDraftSession) { _ in
             // Force re-render when draft state changes
+        }
+        .onChange(of: stealthManager.isStealthActive) { _ in
+            // Stealth toggled — reload sessions and re-filter
+            loadSessions()
         }
     }
 
@@ -146,6 +161,7 @@ struct SessionRowView: View {
     let entry: SessionIndexEntry
     let isActive: Bool
     let isDisabled: Bool
+    let isStealthSession: Bool
     let onSelect: () -> Void
     let onDelete: () -> Void
 
@@ -186,10 +202,17 @@ struct SessionRowView: View {
 
                 HStack(spacing: 8) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(entry.title)
-                            .font(.system(size: 12, weight: isActive ? .semibold : .regular))
-                            .foregroundColor(isDisabled ? .secondary.opacity(0.5) : (isActive ? .primary : .secondary))
-                            .lineLimit(1)
+                        HStack(spacing: 4) {
+                            if isStealthSession {
+                                Image(systemName: "lock.shield.fill")
+                                    .font(.system(size: 10))
+                                    .foregroundColor(DS.Colors.textSecondary)
+                            }
+                            Text(entry.title)
+                                .font(.system(size: 12, weight: isActive ? .semibold : .regular))
+                                .foregroundColor(isDisabled ? .secondary.opacity(0.5) : (isActive ? .primary : .secondary))
+                                .lineLimit(1)
+                        }
 
                         HStack(spacing: 4) {
                             Text(formatDate(entry.updatedAt))

--- a/Extremis/scripts/run-tests.sh
+++ b/Extremis/scripts/run-tests.sh
@@ -296,6 +296,21 @@ run_test_suite "SpeechRecognitionService Tests" \
     "$PROJECT_DIR/Tests/Core/SpeechRecognitionServiceTests.swift" \
     "Foundation" "AVFoundation" "CoreMedia" "CoreAudio"
 
+# 39. Stealth Session Tagging Tests (isStealth property, backward compat)
+run_test_suite "Stealth Session Tagging Tests" \
+    "$PROJECT_DIR/Tests/Core/StealthSessionTaggingTests.swift" \
+    "Foundation"
+
+# 40. Stealth Session Filtering Tests (visibility filtering logic)
+run_test_suite "Stealth Session Filtering Tests" \
+    "$PROJECT_DIR/Tests/Core/StealthSessionFilteringTests.swift" \
+    "Foundation"
+
+# 41. Stealth Auto-Switch Tests (auto-switch on stealth disable)
+run_test_suite "Stealth Auto-Switch Tests" \
+    "$PROJECT_DIR/Tests/Core/StealthAutoSwitchTests.swift" \
+    "Foundation"
+
 # ------------------------------------------------------------------------------
 # Final Summary
 # ------------------------------------------------------------------------------

--- a/specs/016-stealth-chat-isolation/checklists/requirements.md
+++ b/specs/016-stealth-chat-isolation/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Stealth Chat Isolation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-03
+**Feature**: [spec.md](../spec.md)
+**Last Validated**: 2026-06-03 (post-clarification)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass after clarification session (4 questions answered).
+- Clarification added FR-007 (no auto-switch on enable), FR-012 (deletion only in stealth), FR-013/FR-014 (Quick/Magic Mode disabled), SC-006.
+- Session-level isolation confirmed over message-level (documented in Assumptions with rationale).

--- a/specs/016-stealth-chat-isolation/data-model.md
+++ b/specs/016-stealth-chat-isolation/data-model.md
@@ -1,0 +1,115 @@
+# Data Model: Stealth Chat Isolation
+
+**Branch**: `016-stealth-chat-isolation` | **Date**: 2026-06-03
+
+## Entity Changes
+
+### SessionIndexEntry (modified)
+
+Lightweight index entry displayed in the sidebar. Add `isStealth` field.
+
+```
+SessionIndexEntry
+├── id: UUID                    # (existing) Session identifier
+├── title: String               # (existing) Display title
+├── createdAt: Date             # (existing) Creation time
+├── updatedAt: Date             # (existing) Last activity
+├── messageCount: Int           # (existing) Message count
+├── preview: String?            # (existing) First message preview
+├── isArchived: Bool            # (existing) Soft-delete flag
+└── isStealth: Bool             # (NEW) Whether created in stealth mode
+                                # Default: false (backward compat)
+                                # Immutable after creation
+```
+
+**Codable key**: `"isStealth"` — decoded via `decodeIfPresent` with `false` default for backward compatibility with existing index files.
+
+### PersistedSession (modified)
+
+Full session data stored on disk. Add `isStealth` field.
+
+```
+PersistedSession
+├── id: UUID                    # (existing)
+├── version: Int                # (existing) Schema version
+├── messages: [PersistedMessage] # (existing)
+├── initialRequest: String?     # (existing)
+├── maxMessages: Int            # (existing)
+├── createdAt: Date             # (existing)
+├── updatedAt: Date             # (existing)
+├── title: String?              # (existing)
+├── isArchived: Bool            # (existing)
+├── summary: SessionSummary?    # (existing)
+└── isStealth: Bool             # (NEW) Whether created in stealth mode
+                                # Default: false (backward compat)
+                                # Immutable after creation
+```
+
+**Codable key**: `"isStealth"` — decoded via `decodeIfPresent` with `false` default.
+
+### ChatSession (modified)
+
+Live in-memory session. Add `isStealth` property set at creation time.
+
+```
+ChatSession
+├── ... (all existing properties unchanged)
+└── isStealth: Bool             # (NEW) Set at creation, never modified
+                                # Default: false
+                                # Read by SessionManager for tagging
+```
+
+**Not `@Published`** — this value never changes after init, so no observation needed.
+
+## Filtering Logic
+
+### SessionIndex.activeSessions (modified)
+
+Current: `sessions.filter { !$0.isArchived }.sorted { $0.updatedAt > $1.updatedAt }`
+
+This computed property remains unchanged — it continues to return all non-archived sessions. Stealth filtering is applied at a higher layer (sidebar/SessionManager) because it depends on runtime state (`StealthManager.isStealthActive`).
+
+### New Filtering (in SessionManager or SessionListView)
+
+```
+visibleSessions(isStealthActive: Bool) -> [SessionIndexEntry]:
+  if isStealthActive:
+    return activeSessions                    # Show all (stealth + normal)
+  else:
+    return activeSessions.filter { !$0.isStealth }  # Hide stealth sessions
+```
+
+## State Transitions
+
+```
+                    ┌─────────────────┐
+                    │  Session Created │
+                    └────────┬────────┘
+                             │
+                    ┌────────▼────────┐
+                    │ isStealth = X   │  (X = StealthManager.isStealthActive at creation)
+                    └────────┬────────┘
+                             │
+              ┌──────────────┴──────────────┐
+              │                             │
+     ┌────────▼────────┐          ┌────────▼────────┐
+     │ isStealth=false │          │ isStealth=true  │
+     │ (Normal Session) │          │ (Stealth Session)│
+     └────────┬────────┘          └────────┬────────┘
+              │                             │
+              │ Always visible              │ Visible only when
+              │                             │ StealthManager.isStealthActive
+              │                             │
+              ▼                             ▼
+     ┌─────────────────┐          ┌─────────────────┐
+     │ Can be deleted   │          │ Can be deleted   │
+     │ in any mode      │          │ only in stealth  │
+     └─────────────────┘          └─────────────────┘
+```
+
+## Backward Compatibility
+
+- **Existing session files**: `isStealth` absent → decoded as `false` (normal session)
+- **Existing index file**: `isStealth` absent per entry → decoded as `false`
+- **No migration needed**: Codable `decodeIfPresent` handles missing field gracefully
+- **Version field**: `PersistedSession.version` remains at 1 — this is an additive, non-breaking change

--- a/specs/016-stealth-chat-isolation/plan.md
+++ b/specs/016-stealth-chat-isolation/plan.md
@@ -1,0 +1,185 @@
+# Implementation Plan: Stealth Chat Isolation
+
+**Branch**: `016-stealth-chat-isolation` | **Date**: 2026-06-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/016-stealth-chat-isolation/spec.md`
+
+## Summary
+
+Add session-level stealth tagging so conversations created while stealth mode is active are automatically hidden from the sidebar in normal mode and revealed when stealth is re-enabled. Disable Quick Mode and Magic Mode hotkeys in stealth. The approach is purely additive — a boolean `isStealth` flag on sessions, UI-layer filtering, and early-return hotkey guards. No changes to storage structure, no new files for core logic, no breaking changes.
+
+## Technical Context
+
+**Language/Version**: Swift 5.9+ with Swift Concurrency
+**Primary Dependencies**: SwiftUI, AppKit (NSPanel), Combine, Carbon (hotkeys)
+**Storage**: JSON files in `~/Library/Application Support/Extremis/sessions/` (existing)
+**Testing**: Standalone Swift test files compiled with `swiftc`, run via `scripts/run-tests.sh`
+**Target Platform**: macOS 13.0+ (Ventura)
+**Project Type**: Single macOS app (Swift Package Manager)
+**Performance Goals**: Sidebar update within 200ms on stealth toggle, no visible flicker
+**Constraints**: Additive changes only, backward-compatible Codable, zero regressions
+**Scale/Scope**: ~8 files modified, ~3 new test files, ~200-300 lines of new code
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Modularity & Separation of Concerns | PASS | Stealth tag is a data property; filtering is in UI layer; hotkey guards are in existing handler methods. No new coupling between modules. |
+| II. Code Quality & Best Practices | PASS | Follows existing patterns (Codable defaults like `isArchived`, early guards like Magic Mode). No magic numbers. |
+| III. Extensibility & Testability | PASS | `isStealth` is a simple boolean — testable without mocks. Filtering logic is a pure function on arrays. |
+| IV. User Experience Excellence | PASS | Sidebar updates reactively via Combine. Visual indicator on stealth sessions. Auto-switch prevents content exposure. |
+| V. Documentation Synchronization | PASS | CLAUDE.md and README to be updated with stealth isolation behavior. |
+| VI. Testing Discipline | PASS | Unit tests for model backward compat, filtering logic, tagging, and auto-switch. |
+| VII. Regression Prevention | PASS | All changes are additive. Existing sessions default to `isStealth: false`. Existing tests must pass at each step. |
+
+**Post-design re-check**: All gates still PASS. No constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-stealth-chat-isolation/
+├── spec.md              # Feature specification
+├── plan.md              # This file
+├── research.md          # Phase 0 research decisions
+├── data-model.md        # Entity changes and state transitions
+├── quickstart.md        # Step-by-step implementation guide
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Phase 2 output (created by /speckit.tasks)
+```
+
+### Source Code (files modified/created)
+
+```text
+Extremis/
+├── Core/
+│   ├── Models/
+│   │   ├── ChatSession.swift              # ADD isStealth property
+│   │   └── Persistence/
+│   │       ├── PersistedSession.swift      # ADD isStealth field (Codable)
+│   │       └── SessionIndex.swift          # ADD isStealth to SessionIndexEntry
+│   └── Services/
+│       ├── SessionManager.swift            # Tag new sessions, auto-switch on stealth disable
+│       └── JSONSessionStorage.swift        # Pass isStealth through index updates
+├── UI/
+│   └── PromptWindow/
+│       └── SessionListView.swift           # Filter by stealth, add visual indicator
+├── App/
+│   └── AppDelegate.swift                   # Add stealth guard for Quick Mode path
+└── Tests/
+    └── Core/
+        ├── StealthSessionTaggingTests.swift    # NEW: tagging and backward compat tests
+        ├── StealthSessionFilteringTests.swift   # NEW: filtering logic tests
+        └── StealthAutoSwitchTests.swift         # NEW: auto-switch behavior tests
+```
+
+**Structure Decision**: All changes go into existing files following the established project structure. Three new test files in `Tests/Core/` following the standalone `TestRunner` pattern.
+
+## Design Details
+
+### 1. Data Model Changes
+
+**ChatSession** — Add `let isStealth: Bool` (immutable, set at init):
+```swift
+init(originalContext: Context? = nil, initialRequest: String? = nil, isStealth: Bool = false)
+```
+
+**PersistedSession** — Add `let isStealth: Bool` with backward-compatible decoding:
+```swift
+isStealth = try container.decodeIfPresent(Bool.self, forKey: .isStealth) ?? false
+```
+
+**SessionIndexEntry** — Same pattern as PersistedSession. The `isStealth` value is copied from the session when the index is updated in `JSONSessionStorage.saveSession()`.
+
+### 2. Session Tagging
+
+In `SessionManager.startNewSession()`:
+```swift
+let session = ChatSession(
+    originalContext: context,
+    initialRequest: initialRequest,
+    isStealth: StealthManager.shared.isStealthActive  // NEW
+)
+```
+
+The tag flows through: `ChatSession.isStealth` → `PersistedSession.from()` → `JSONSessionStorage.saveSession()` → `SessionIndexEntry.isStealth`.
+
+### 3. Sidebar Filtering
+
+In `SessionListView`, add `@ObservedObject` for `StealthManager.shared` and filter:
+```swift
+let visibleSessions = stealthManager.isStealthActive
+    ? sessions                                    // Stealth: show all
+    : sessions.filter { !$0.isStealth }           // Normal: hide stealth
+```
+
+Refresh triggers: existing `sessionListVersion` + new `onChange(of: stealthManager.isStealthActive)`.
+
+### 4. Visual Indicator
+
+In `SessionRowView`, when `entry.isStealth && stealthManager.isStealthActive`:
+- Show SF Symbol `lock.shield.fill` (small, muted color) next to session title
+- Use `DS.Colors.textSecondary` for the icon
+
+### 5. Active Session Auto-Switch
+
+In `SessionManager.init()`, subscribe to stealth state:
+```swift
+StealthManager.shared.$isStealthActive
+    .dropFirst()  // Skip initial value
+    .sink { [weak self] isActive in
+        if !isActive { self?.handleStealthDeactivation() }
+    }
+```
+
+`handleStealthDeactivation()`:
+1. Check if `currentSession?.isStealth == true`
+2. If yes: load most recent normal session from index, or set `currentSession = nil`
+3. Increment `sessionListVersion` to trigger sidebar refresh
+
+### 6. Hotkey Guards
+
+**Quick Mode** (Option+Space with selection): In `AppDelegate.captureContextAndShowPrompt()`, the existing stealth check at line 673 already skips selection detection. Extend this to fully skip the Quick Mode path — when stealth is active AND selection was detected, treat as Chat Mode (no selection) instead.
+
+**Magic Mode** (Option+Tab): Already guarded at `handleMagicModeActivation()` line 610 — no change needed.
+
+### 7. Testing Strategy
+
+All tests follow the existing standalone `TestRunner` pattern:
+
+**StealthSessionTaggingTests.swift**:
+- Test `ChatSession` creation with `isStealth: true` and `false`
+- Test `PersistedSession` encoding/decoding with `isStealth`
+- Test backward compat: decode JSON without `isStealth` field → defaults to `false`
+- Test `SessionIndexEntry` backward compat same way
+- Test round-trip: `ChatSession` → `PersistedSession` → `ChatSession` preserves `isStealth`
+
+**StealthSessionFilteringTests.swift**:
+- Test filter: stealth active → returns all sessions
+- Test filter: stealth inactive → excludes stealth sessions
+- Test filter: no stealth sessions → same result in both modes
+- Test filter: all stealth sessions + stealth off → empty list
+- Test filter: mixed sessions sorted correctly
+
+**StealthAutoSwitchTests.swift**:
+- Test: stealth disable with active stealth session → switches to most recent normal
+- Test: stealth disable with active normal session → no change
+- Test: stealth disable with no normal sessions → clears active session
+- Test: stealth enable → no session change
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Existing session files break on load | Low | High | `decodeIfPresent` with default — tested explicitly |
+| Sidebar flicker on stealth toggle | Low | Medium | Combine-driven reactive update, same as existing `sessionListVersion` |
+| Active session not switched on stealth disable | Medium | High | Explicit Combine subscription + unit test |
+| Quick Mode accidentally works in stealth | Low | Medium | Early guard + manual QA verification |
+| Performance regression with filtering | Very Low | Low | Simple array filter on <100 sessions |
+
+## Complexity Tracking
+
+No constitution violations — no entries needed.

--- a/specs/016-stealth-chat-isolation/quickstart.md
+++ b/specs/016-stealth-chat-isolation/quickstart.md
@@ -1,0 +1,57 @@
+# Quickstart: Stealth Chat Isolation
+
+**Branch**: `016-stealth-chat-isolation` | **Date**: 2026-06-03
+
+## Overview
+
+Add session-level stealth tagging so conversations created during stealth mode are hidden from the sidebar in normal mode. Minimal, additive changes to existing models and services.
+
+## Implementation Order
+
+### Step 1: Data Model (additive, no behavior change)
+1. Add `isStealth: Bool` to `ChatSession` (init parameter, default `false`)
+2. Add `isStealth: Bool` to `PersistedSession` (Codable, `decodeIfPresent` default `false`)
+3. Add `isStealth: Bool` to `SessionIndexEntry` (Codable, `decodeIfPresent` default `false`)
+4. Pass `isStealth` through in `PersistedSession.from(_:)` and `toSession()` conversions
+5. Pass `isStealth` through in `JSONSessionStorage.saveSession()` index update
+
+**Verification**: Build succeeds, all existing tests pass, no behavior change.
+
+### Step 2: Session Tagging (creation-time tagging)
+1. In `SessionManager.startNewSession()`, set `isStealth = StealthManager.shared.isStealthActive`
+2. Ensure the tag flows through save → index → load round-trip
+
+**Verification**: Create session in stealth → check persisted JSON has `isStealth: true`.
+
+### Step 3: Sidebar Filtering (visibility)
+1. In `SessionListView`, observe `StealthManager.shared.$isStealthActive`
+2. Filter `sessions` array: if stealth off, exclude `isStealth == true` entries
+3. Add stealth visual indicator (SF Symbol `lock.shield.fill`) on stealth sessions when stealth is active
+
+**Verification**: Toggle stealth → stealth sessions appear/disappear in sidebar.
+
+### Step 4: Active Session Auto-Switch (on stealth disable)
+1. In `SessionManager`, subscribe to `StealthManager.shared.$isStealthActive`
+2. When stealth goes `true → false` and current session is stealth: switch to most recent normal session or clear
+
+**Verification**: View stealth session → disable stealth → active session switches.
+
+### Step 5: Hotkey Guards (Quick Mode + Magic Mode)
+1. In `AppDelegate.handleHotkeyActivation()`: add early return when stealth is active AND selection exists (Quick Mode path)
+2. Verify existing Magic Mode guard at line 610 (already implemented)
+
+**Verification**: In stealth, select text + Option+Space → no-op. Option+Tab → no-op (already works).
+
+### Step 6: Unit Tests
+1. Test `SessionIndexEntry` / `PersistedSession` backward compatibility (missing `isStealth` → `false`)
+2. Test filtering logic (stealth on → all sessions, stealth off → only normal)
+3. Test stealth tag immutability (tag set at creation, preserved through save/load)
+4. Test auto-switch logic (stealth disable with active stealth session)
+
+## Key Principles (per user request)
+
+- **Simple & minimal**: Each step is a small, additive change
+- **No regressions**: Backward-compatible Codable defaults, existing tests must pass at each step
+- **Configurable**: Stealth tag driven by `StealthManager.isStealthActive` (already configurable)
+- **High quality**: Follow existing patterns (filtering like `isArchived`, guards like Magic Mode)
+- **Unit tested**: Every behavioral change has corresponding tests

--- a/specs/016-stealth-chat-isolation/research.md
+++ b/specs/016-stealth-chat-isolation/research.md
@@ -1,0 +1,78 @@
+# Research: Stealth Chat Isolation
+
+**Branch**: `016-stealth-chat-isolation` | **Date**: 2026-06-03
+
+## Decision 1: Isolation Granularity — Session-Level vs Message-Level
+
+**Decision**: Session-level isolation (entire sessions tagged as stealth or normal).
+
+**Rationale**: Message-level isolation creates LLM conversation coherence problems — the assistant may reference stealth content in a normal-mode response, leaking context. Session-level follows proven patterns (WhatsApp Chat Lock, Telegram Secret Chats) and is simpler to implement.
+
+**Alternatives considered**:
+- Message-level tagging (Instagram Vanish Mode pattern) — rejected due to LLM context leak risk and rendering complexity
+- Hybrid (session with message overrides) — over-engineered for the use case
+
+## Decision 2: Storage Approach — UI Filtering vs Separate Storage
+
+**Decision**: UI-layer filtering with shared storage. The `isStealth` flag is added to `SessionIndexEntry` and `PersistedSession`. Filtering happens in the sidebar view, not at the storage layer.
+
+**Rationale**: Shared storage is simpler — no need for separate directories, backup strategies, or migration logic. The threat model is screen-sharing observers, not filesystem attackers. Existing `SessionIndex.activeSessions` computed property already demonstrates the filtering pattern (filters `isArchived`).
+
+**Alternatives considered**:
+- Separate storage directory for stealth sessions — more complex, minimal security benefit for the use case
+- Encrypted stealth storage — over-engineered; the user's filesystem is already trusted
+
+## Decision 3: Stealth Tag Mutability
+
+**Decision**: Immutable after session creation. A session created in stealth stays stealth forever.
+
+**Rationale**: Prevents accidental exposure through tag toggling. Matches the mental model — "this conversation happened during stealth." Simplifies UI (no toggle controls needed).
+
+**Alternatives considered**:
+- User-togglable tag — risk of accidental exposure, more UI complexity
+- Auto-convert on mode switch — confusing, violates user expectations
+
+## Decision 4: Quick Mode / Magic Mode in Stealth
+
+**Decision**: Disable both (no-op) when stealth is active.
+
+**Rationale**: Quick Mode inserts text into the active app and Magic Mode copies to clipboard — both leave traces outside Extremis. Chat Mode remains functional (creates stealth sessions). Existing pattern: Magic Mode already has a stealth guard at `AppDelegate.handleMagicModeActivation()` line 610.
+
+**Alternatives considered**:
+- Allow but don't persist — traces still left in clipboard/target app
+- Allow with warning — adds UI complexity for minimal value
+
+## Decision 5: Active Session Behavior on Stealth Toggle
+
+**Decision**:
+- **On stealth enable**: No change to active session (keep current normal session active)
+- **On stealth disable**: Auto-switch away from stealth session to most recent normal session (or empty state)
+
+**Rationale**: Enabling stealth is a background action — user shouldn't lose context. Disabling stealth must hide stealth content immediately — can't leave it on screen.
+
+## Decision 6: Backward Compatibility for Existing Sessions
+
+**Decision**: Existing sessions (created before this feature) default to `isStealth = false`. The `SessionIndexEntry` and `PersistedSession` decoders use `decodeIfPresent` with a `false` default.
+
+**Rationale**: All pre-existing sessions were created in normal mode. No migration needed — just a Codable default.
+
+## Key Codebase Findings
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `Core/Models/Persistence/SessionIndex.swift` | Add `isStealth: Bool` to `SessionIndexEntry` |
+| `Core/Models/Persistence/PersistedSession.swift` | Add `isStealth: Bool` to `PersistedSession` |
+| `Core/Models/ChatSession.swift` | Add `isStealth: Bool` property (set at creation) |
+| `Core/Services/SessionManager.swift` | Tag new sessions, filter on stealth toggle, auto-switch on disable |
+| `Core/Services/JSONSessionStorage.swift` | Pass through `isStealth` in index updates |
+| `UI/PromptWindow/SessionListView.swift` | Filter sessions by stealth state, add visual indicator |
+| `App/AppDelegate.swift` | Add stealth guard to `handleHotkeyActivation()` for Quick Mode path |
+
+### Existing Patterns to Follow
+
+1. **Filtering**: `SessionIndex.activeSessions` filters `isArchived` — extend with `isStealth` filtering
+2. **Stealth guards**: `handleMagicModeActivation()` line 610 uses early `guard` — replicate for Quick Mode
+3. **Reactive observation**: `VoiceInputManager` subscribes to `StealthManager.$isStealthActive` via Combine — SessionManager should do the same for auto-switch
+4. **Codable backward compat**: `SessionIndexEntry` already handles schema evolution with `decodeIfPresent` — follow same pattern

--- a/specs/016-stealth-chat-isolation/spec.md
+++ b/specs/016-stealth-chat-isolation/spec.md
@@ -1,0 +1,135 @@
+# Feature Specification: Stealth Chat Isolation
+
+**Feature Branch**: `016-stealth-chat-isolation`
+**Created**: 2026-06-03
+**Status**: Draft
+**Input**: User description: "Build a feature so that chats / messages in stealth should be visible only in stealth and not in normal mode"
+
+## User Scenarios & Testing
+
+### User Story 1 - Stealth Sessions Hidden in Normal Mode (Priority: P1)
+
+As a user who has had conversations while stealth mode was active, I want those conversations to be automatically hidden from the session sidebar when I switch back to normal mode, so that anyone glancing at my screen cannot see sensitive stealth conversations.
+
+**Why this priority**: This is the core value proposition — stealth conversations must never leak into the normal-mode UI. Without this, stealth mode only hides the window from screen share but the conversation history remains fully visible afterward.
+
+**Independent Test**: Can be fully tested by enabling stealth mode, having a conversation, disabling stealth mode, and verifying the conversation no longer appears in the sidebar or chat history.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has active conversations created during stealth mode, **When** the user disables stealth mode, **Then** those conversations disappear from the session sidebar.
+2. **Given** the user is in normal mode, **When** the user browses the session sidebar, **Then** no stealth-tagged conversations are visible.
+3. **Given** the user is in normal mode and a stealth session was previously the active chat, **When** stealth mode is disabled, **Then** the active view switches to the most recent normal-mode session (or a blank state if none exist).
+
+---
+
+### User Story 2 - Stealth Sessions Visible in Stealth Mode (Priority: P1)
+
+As a user who re-enters stealth mode, I want to see all my previous stealth conversations alongside my normal conversations, so that I can continue sensitive chats or reference normal ones as needed.
+
+**Why this priority**: Equal priority to Story 1 — stealth conversations must be accessible when stealth mode is active, otherwise the isolation feature breaks usability. Showing both types gives the user full flexibility.
+
+**Independent Test**: Can be fully tested by enabling stealth mode, creating a conversation, disabling stealth mode, then re-enabling stealth mode and verifying the conversation reappears alongside normal sessions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has previously created stealth conversations, **When** the user enables stealth mode, **Then** all stealth-tagged conversations appear in the session sidebar alongside normal sessions.
+2. **Given** the user is in stealth mode, **When** the user creates a new conversation, **Then** the conversation is automatically tagged as a stealth conversation.
+3. **Given** the user is in stealth mode, **When** the user opens a stealth conversation, **Then** all messages and history are fully accessible.
+4. **Given** the user is in stealth mode, **When** the user opens a normal session, **Then** they can continue conversing in it normally (messages remain normal-tagged).
+
+---
+
+### User Story 3 - Stealth Visual Indicator on Sessions (Priority: P2)
+
+As a user in stealth mode viewing my session sidebar, I want a subtle visual indicator distinguishing stealth sessions from normal sessions so that I understand which conversations are protected.
+
+**Why this priority**: When stealth mode is active, the user sees both stealth and normal sessions. A visual indicator helps the user understand which sessions will disappear when stealth is disabled.
+
+**Independent Test**: Can be fully tested by enabling stealth mode with a mix of stealth and normal sessions and verifying a visual distinction exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** stealth mode is active and the sidebar shows both stealth and normal sessions, **When** the user looks at the sidebar, **Then** stealth sessions have a subtle visual indicator (e.g., a small lock or shield icon) distinguishing them from normal sessions.
+2. **Given** stealth mode is disabled, **When** the user views the sidebar, **Then** no stealth indicators are visible (stealth sessions are hidden entirely).
+
+---
+
+### User Story 4 - Session Persistence Across App Restarts (Priority: P2)
+
+As a user, I want my stealth conversations to persist across app restarts and remain properly isolated, so that quitting and reopening the app does not lose stealth conversations or accidentally expose them in normal mode.
+
+**Why this priority**: Persistence ensures the isolation guarantee survives app lifecycle events. Without this, stealth sessions could either be lost or inadvertently exposed after restart.
+
+**Independent Test**: Can be fully tested by creating stealth conversations, quitting the app, reopening it in normal mode, verifying stealth sessions are hidden, then enabling stealth mode and verifying they reappear.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has stealth conversations and restarts the app in normal mode, **When** the app launches, **Then** stealth sessions are not visible in the sidebar.
+2. **Given** the user has stealth conversations and restarts the app, **When** the user enables stealth mode, **Then** all previous stealth sessions are visible and intact.
+
+---
+
+### Edge Cases
+
+- What happens if the user toggles stealth mode rapidly? The sidebar should always reflect the current stealth state without visual glitches or stale entries.
+- What happens if the user is actively viewing a stealth session and disables stealth mode? The view should transition to a non-stealth session or blank state — the stealth session content must not remain on screen.
+- What happens if all sessions are stealth sessions and the user disables stealth mode? The sidebar shows an empty state with guidance to create a new conversation.
+- What happens if the user creates a session in normal mode and then enables stealth? The existing normal session remains tagged as normal and continues to be visible in both modes. The user can still converse in it while stealth is active.
+- What happens if a background generation is running on a stealth session when stealth is disabled? The generation continues in the background, but the session is hidden from the sidebar. Notifications (if any) should not reveal stealth content.
+- What happens when the user enables stealth mode? The current normal session (if any) stays active — no automatic session switch occurs. The user can manually switch to or create a stealth session.
+- What happens if the user wants to delete a stealth session? Stealth sessions can only be deleted while stealth mode is active, since they are not visible in normal mode.
+- What happens if the user presses Option+Space (with selection) or Option+Tab in stealth mode? Quick Mode and Magic Mode are disabled in stealth mode. The hotkey is silently ignored (no-op) to prevent transient interactions that could leave traces in clipboard or insertion targets.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST tag every new conversation created while stealth mode is active as a stealth session.
+- **FR-002**: System MUST hide all stealth-tagged sessions from the session sidebar when stealth mode is disabled.
+- **FR-003**: System MUST show all stealth-tagged sessions in the session sidebar when stealth mode is enabled.
+- **FR-004**: System MUST show all normal (non-stealth) sessions in the sidebar regardless of stealth mode state. Users can continue conversing in normal sessions while stealth is active.
+- **FR-005**: System MUST persist the stealth tag as part of the session data so isolation survives app restarts.
+- **FR-006**: System MUST automatically switch the active session away from a stealth session when the user disables stealth mode (transition to the most recent normal session, or an empty state if none exist).
+- **FR-007**: System MUST keep the current active session unchanged when stealth mode is enabled — no automatic session switch on stealth activation.
+- **FR-008**: System MUST display a visual indicator (e.g., lock or shield icon) on stealth sessions in the sidebar when stealth mode is active.
+- **FR-009**: System MUST ensure stealth session content (titles, previews, message snippets) never appears in normal mode UI, including any search results or session previews.
+- **FR-010**: System MUST continue background operations (e.g., in-progress generation) on stealth sessions even when stealth mode is disabled, without exposing content.
+- **FR-011**: System MUST NOT allow a session's stealth tag to change after creation — a session created in stealth stays stealth, a session created in normal mode stays normal.
+- **FR-012**: System MUST only allow deletion of stealth sessions while stealth mode is active (stealth sessions are not accessible for deletion in normal mode).
+- **FR-013**: System MUST disable Quick Mode (Option+Space with text selection) when stealth mode is active. The hotkey MUST be silently ignored (no-op).
+- **FR-014**: System MUST disable Magic Mode (Option+Tab) when stealth mode is active. The hotkey MUST be silently ignored (no-op).
+
+### Key Entities
+
+- **Stealth Tag**: A boolean property on each conversation/session indicating whether it was created during stealth mode. Immutable after creation.
+- **Session Visibility Filter**: Logic that filters the session list based on the current stealth mode state — in normal mode shows only normal sessions; in stealth mode shows all sessions (stealth + normal).
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: When stealth mode is disabled, zero stealth-tagged sessions are visible in the sidebar, search results, or any other UI surface.
+- **SC-002**: When stealth mode is enabled, 100% of stealth-tagged sessions are accessible in the sidebar alongside normal sessions.
+- **SC-003**: Stealth session isolation persists correctly across app restarts — no stealth content is exposed during or after app relaunch in normal mode.
+- **SC-004**: Toggling stealth mode updates the sidebar session list within 200ms with no visible flicker.
+- **SC-005**: Users can distinguish stealth sessions from normal sessions at a glance when stealth mode is active.
+- **SC-006**: Quick Mode and Magic Mode hotkeys produce no response or side effects when stealth mode is active.
+
+## Clarifications
+
+### Session 2026-06-03
+
+- Q: When stealth mode is enabled, what happens to the active session? → A: The current active session stays unchanged — no automatic session switch on stealth activation. The user manually switches to or creates a stealth session if desired.
+- Q: Can users converse in normal sessions while stealth mode is active? → A: Yes. Normal sessions are always accessible regardless of stealth state. Users can freely switch between stealth and normal sessions in stealth mode. New sessions auto-tag based on current mode.
+- Q: Can stealth sessions be deleted, and from which mode? → A: Stealth sessions can only be deleted while stealth mode is active — they are not visible or accessible in normal mode, so deletion naturally requires stealth to be on.
+- Q: Should Quick Mode and Magic Mode work in stealth mode? → A: No. Both are disabled in stealth mode — hotkeys are silently ignored to prevent transient interactions that could leave traces (clipboard, text insertion).
+
+## Assumptions
+
+- The existing session/conversation model can be extended with a boolean stealth tag without breaking backward compatibility. Existing sessions default to non-stealth.
+- `StealthManager.shared.isStealthActive` is the single source of truth for current stealth state and is already observable.
+- Session filtering is applied at the UI layer (sidebar view model) rather than at the storage layer, so stealth sessions remain persisted and intact regardless of mode.
+- The stealth tag is immutable after session creation to prevent accidental exposure through tag toggling.
+- Isolation is at the session level (not message level) to maintain LLM conversation coherence and follow established industry patterns (WhatsApp Chat Lock, Telegram Secret Chats).
+- Chat Mode (Option+Space without selection) remains functional in stealth — it opens the prompt window for stealth chat sessions. Only Quick Mode (with selection) and Magic Mode are disabled.

--- a/specs/016-stealth-chat-isolation/tasks.md
+++ b/specs/016-stealth-chat-isolation/tasks.md
@@ -1,0 +1,169 @@
+# Tasks: Stealth Chat Isolation
+
+**Input**: Design documents from `/specs/016-stealth-chat-isolation/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: Included — user requested unit tests for all applicable changes.
+
+**Organization**: Tasks grouped by user story. US1+US2 are combined (both P1, share filtering logic). US4 (persistence) is covered by foundational data model tasks — no separate phase needed.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Foundational (Data Model)
+
+**Purpose**: Add `isStealth` boolean to all session models and storage. Purely additive, no behavior change. All existing tests must still pass after this phase.
+
+- [X] T001 [P] Add `isStealth: Bool` property to `ChatSession` init (default `false`, immutable `let`) in `Extremis/Core/Models/ChatSession.swift`
+- [X] T002 [P] Add `isStealth: Bool` field to `PersistedSession` with backward-compatible Codable decoding (`decodeIfPresent` defaulting to `false`) in `Extremis/Core/Models/Persistence/PersistedSession.swift`
+- [X] T003 [P] Add `isStealth: Bool` field to `SessionIndexEntry` with backward-compatible Codable decoding (`decodeIfPresent` defaulting to `false`) in `Extremis/Core/Models/Persistence/SessionIndex.swift`
+- [X] T004 Pass `isStealth` through `PersistedSession.from(_:)` conversion (read from `ChatSession.isStealth`) and `toSession()` restoration in `Extremis/Core/Models/Persistence/PersistedSession.swift`
+- [X] T005 Pass `isStealth` through index entry creation in `JSONSessionStorage.saveSession()` — when creating/updating `SessionIndexEntry`, copy `isStealth` from the `PersistedSession` in `Extremis/Core/Services/JSONSessionStorage.swift`
+- [X] T006 Run existing test suite (`./scripts/run-tests.sh`) and verify zero regressions — all existing tests must pass with the new fields defaulting to `false`
+
+**Checkpoint**: Data model complete. `isStealth` flows through create → persist → index → restore. No behavior change yet.
+
+---
+
+## Phase 2: User Stories 1 & 2 — Session Tagging, Filtering, and Auto-Switch (Priority: P1) MVP
+
+**Goal**: New sessions created in stealth mode are tagged `isStealth: true`. Sidebar hides stealth sessions in normal mode and shows all sessions in stealth mode. Active session auto-switches away from stealth on stealth disable. Quick Mode disabled in stealth.
+
+**Independent Test**: Enable stealth → create conversation → disable stealth → conversation disappears from sidebar. Re-enable stealth → conversation reappears.
+
+### Tests for US1+US2
+
+- [X] T007 [P] [US1] Create `Extremis/Tests/Core/StealthSessionTaggingTests.swift` — test `ChatSession` creation with `isStealth: true/false`, test `PersistedSession` encode/decode round-trip preserves `isStealth`, test backward compat (JSON without `isStealth` field decodes as `false`), test `SessionIndexEntry` backward compat same way
+- [X] T008 [P] [US1] Create `Extremis/Tests/Core/StealthSessionFilteringTests.swift` — test pure filtering function: stealth active returns all sessions, stealth inactive excludes `isStealth` entries, empty list when all stealth + stealth off, mixed sessions preserve sort order
+- [X] T009 [P] [US1] Create `Extremis/Tests/Core/StealthAutoSwitchTests.swift` — test auto-switch logic: stealth disable with active stealth session returns most recent normal session ID, stealth disable with active normal session returns nil (no switch), stealth disable with no normal sessions returns nil (clear), stealth enable returns nil (no switch)
+- [X] T010 Add all three new test files to `Extremis/scripts/run-tests.sh` and verify they compile and run
+
+### Implementation for US1+US2
+
+- [X] T011 [US1] In `SessionManager.startNewSession()`, set `isStealth: StealthManager.shared.isStealthActive` when creating the new `ChatSession` in `Extremis/Core/Services/SessionManager.swift`
+- [X] T012 [US1] In `SessionListView`, add `@ObservedObject var stealthManager = StealthManager.shared` and filter `sessions` array: if stealth inactive, exclude entries where `isStealth == true`. Add `onChange(of: stealthManager.isStealthActive)` to trigger session list reload in `Extremis/UI/PromptWindow/SessionListView.swift`
+- [X] T013 [US1] In `SessionManager`, add Combine subscription to `StealthManager.shared.$isStealthActive` (with `.dropFirst()`) — on stealth deactivation, call new `handleStealthDeactivation()` method. This method: checks if `currentSession?.isStealth == true`, if so loads most recent normal session from storage (or sets `currentSession = nil`), increments `sessionListVersion` in `Extremis/Core/Services/SessionManager.swift`
+- [X] T014 [US1] In `AppDelegate.captureContextAndShowPrompt()`, extend the existing stealth check (line ~673) to fully no-op the Quick Mode path: when stealth is active and a selection was detected, discard the selection and proceed as Chat Mode (no selection) instead. Verify Magic Mode guard already exists at `handleMagicModeActivation()` line ~610 in `Extremis/App/AppDelegate.swift`
+- [X] T015 [US1] Run full test suite (`./scripts/run-tests.sh`) — all tests (existing + new) must pass
+
+**Checkpoint**: US1+US2 MVP complete. Stealth sessions are tagged, hidden in normal mode, visible in stealth mode. Auto-switch works. Quick Mode disabled in stealth.
+
+---
+
+## Phase 3: User Story 3 — Stealth Visual Indicator (Priority: P2)
+
+**Goal**: Stealth sessions show a subtle lock/shield icon in the sidebar when stealth mode is active, helping users distinguish protected sessions from normal ones.
+
+**Independent Test**: Enable stealth with a mix of stealth and normal sessions → stealth sessions show icon, normal sessions don't.
+
+### Implementation for US3
+
+- [X] T016 [US3] In `SessionRowView` within `SessionListView`, add a stealth indicator: when `entry.isStealth` is true and stealth mode is active, show SF Symbol `lock.shield.fill` (size ~10pt, color `DS.Colors.textSecondary`) next to the session title. Pass `isStealthActive` state to the row view in `Extremis/UI/PromptWindow/SessionListView.swift`
+- [X] T017 [US3] Verify the indicator does NOT appear in normal mode (stealth sessions are hidden entirely, so this is automatic) — manual QA check
+
+**Checkpoint**: Visual indicator complete. Stealth sessions are visually distinguishable in stealth mode.
+
+---
+
+## Phase 4: User Story 4 — Persistence Verification (Priority: P2)
+
+**Goal**: Verify stealth session isolation persists across app restarts — stealth sessions stay hidden after relaunch in normal mode.
+
+**Note**: The data model work in Phase 1 (T002, T003, T004, T005) already ensures persistence. This phase is verification only.
+
+- [X] T018 [US4] Verify persistence round-trip: create a stealth session, save it, reload from disk, confirm `isStealth == true` is preserved in index and session file. This is covered by T007 tests — verify those tests pass
+- [X] T019 [US4] Manual QA: create stealth session → quit app → relaunch in normal mode → verify stealth session hidden → enable stealth → verify session reappears with all messages intact
+
+**Checkpoint**: Persistence verified. Stealth isolation survives app lifecycle.
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, final validation, cleanup
+
+- [X] T020 Update `Extremis/docs/` and feature documentation to describe stealth chat isolation behavior, session tagging, and hotkey restrictions in stealth mode
+- [X] T021 Run full test suite one final time (`./scripts/run-tests.sh`) and verify all tests pass (existing + new stealth tests)
+- [X] T022 Manual QA: exercise all edge cases from spec — rapid stealth toggle, active stealth session on disable, all-stealth-sessions empty state, background generation on hidden stealth session, Quick Mode no-op in stealth
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Foundational)**: No dependencies — start immediately
+- **Phase 2 (US1+US2)**: Depends on Phase 1 completion
+- **Phase 3 (US3)**: Depends on Phase 2 (needs filtering in place to test indicator visibility)
+- **Phase 4 (US4)**: Depends on Phase 1 (data model) — can run in parallel with Phase 2/3
+- **Phase 5 (Polish)**: Depends on all prior phases
+
+### User Story Dependencies
+
+- **US1+US2 (P1)**: Depends on foundational data model — core MVP, must complete first
+- **US3 (P2)**: Depends on US1+US2 (needs sidebar filtering to show mixed sessions in stealth)
+- **US4 (P2)**: Independent of US1+US2 at the data level, but verification is most meaningful after filtering works
+
+### Parallel Opportunities
+
+Within Phase 1:
+- T001, T002, T003 can run in parallel (different files)
+
+Within Phase 2 tests:
+- T007, T008, T009 can run in parallel (different test files)
+
+Phase 4 can overlap with Phase 3 (different concerns).
+
+---
+
+## Parallel Example: Phase 1
+
+```bash
+# Launch all model changes in parallel (different files):
+Task: "Add isStealth to ChatSession in Extremis/Core/Models/ChatSession.swift"
+Task: "Add isStealth to PersistedSession in Extremis/Core/Models/Persistence/PersistedSession.swift"
+Task: "Add isStealth to SessionIndexEntry in Extremis/Core/Models/Persistence/SessionIndex.swift"
+```
+
+## Parallel Example: Phase 2 Tests
+
+```bash
+# Launch all test file creation in parallel:
+Task: "Create StealthSessionTaggingTests.swift in Extremis/Tests/Core/"
+Task: "Create StealthSessionFilteringTests.swift in Extremis/Tests/Core/"
+Task: "Create StealthAutoSwitchTests.swift in Extremis/Tests/Core/"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1+US2 Only)
+
+1. Complete Phase 1: Data model changes (T001-T006)
+2. Complete Phase 2: Tagging + filtering + auto-switch + tests (T007-T015)
+3. **STOP and VALIDATE**: Test stealth isolation end-to-end
+4. This alone delivers the core value — stealth sessions hidden in normal mode
+
+### Incremental Delivery
+
+1. Phase 1 → Data model ready
+2. Phase 2 → US1+US2 MVP → Test independently (core isolation works)
+3. Phase 3 → US3 visual indicator → Test independently (stealth sessions distinguishable)
+4. Phase 4 → US4 persistence verified → Test independently (survives restarts)
+5. Phase 5 → Polish, docs, final QA
+
+---
+
+## Notes
+
+- All changes are additive — existing sessions default to `isStealth: false`
+- Backward compatibility is critical — test explicitly with JSON lacking `isStealth` field
+- US1+US2 are combined because filtering logic is a single `if/else` that satisfies both
+- US4 persistence is inherently covered by the Codable changes in Phase 1
+- Total: 22 tasks across 5 phases


### PR DESCRIPTION
## Stealth Chat Isolation

Sessions created during stealth mode are now fully isolated — invisible in normal mode and accessible only when stealth is active. This prevents stealth sessions from leaking into the normal session list, keeping sensitive conversations siloed by design.

---

### What Changed

**Session Tagging**
- Immutable `isStealth: Bool` flag on `ChatSession`, `PersistedSession`, and `SessionIndexEntry`
- All 4 `ChatSession()` creation sites updated to propagate the flag correctly

**Sidebar Filtering**
- Stealth sessions hidden in normal mode via `visibleSessions` computed property
- Sidebar rows show a lock/shield indicator on stealth sessions
- `restoreLastSession()` skips stealth sessions when not in stealth mode

**Auto-Switch on Stealth Disable**
- Automatically switches to the most recent normal session when stealth is deactivated
- View model syncs state on auto-switch; separate `Cancellable` sets for session vs. long-lived subscriptions

**Chat Header**
- "Stealth Session" badge with lock/shield icon for clear in-context awareness

**Memory & Persistence**
- Stealth sessions evicted from `sessionCache` on stealth deactivation
- Backward-compatible `Codable` via `decodeIfPresent` — old session files default to `false`

---

### Testing

- [x] Build passes (`swift build`)
- [x] All 2,259 tests pass across 42 suites
- [x] 39 new unit tests: tagging (13), filtering (19), auto-switch (7)
- [x] Manual testing completed

---

### Checklist

- [x] Code follows project conventions
- [x] No new warnings introduced
- [x] `CLAUDE.md` updated

Closes #133